### PR TITLE
Change main path in package.json to HID.node file

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "preinstall": "sh get-hidapi.sh",
         "install": "sh install.sh"
     },
-    "main": "./src/HID",
+    "main": "./src/build/Release/HID",
     "engines": {
         "node": ">=0.8.0"
     },


### PR DESCRIPTION
I had trouble using node-hid on some systems where it couldn't find the package (while it did install in node_modules and compiled successfully). This fix did work for all of the systems I've tried and it seems more logical to me. It changes the main-reference from ./src/HID.cc to ./src/build/Release/HID.node. I couldn't figure out from the documentation where the 'main' entry should be pointing to, but this was the way it worked on my systems.

I haven't done much with 'native' node modules, so I could be missing something very obvious. If so, I'm really interested to know why I am getting 'Cannot find module' for both "require('HID')" and "require('node-hid')" on some systems (Ubuntu 11.04 with node v0.8.15 in this case).
