### PR TITLE
Use node-gyp to build instead of node-waf

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ program can be used to display all HID devices in the system.
 ### Load the extension
 
 ```
-var HID = require('HID');
+var HID = require('node-hid');
 ```
 
 ### Get a list of all HID devices in the system:

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,5 @@
 
 set -e
 
-cd src
-[ -d build ] && node-waf clean
-node-waf configure build install
+[ -d build ] && node-gyp clean
+node-gyp configure build install

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "preinstall": "sh get-hidapi.sh",
         "install": "sh install.sh"
     },
-    "main": "./src/build/Release/HID",
+    "main": "./build/Release/HID.node",
     "engines": {
         "node": ">=0.8.0"
     },

--- a/src/buzzers.js
+++ b/src/buzzers.js
@@ -2,7 +2,7 @@
 
 var util = require('util');
 var events = require('events');
-var HID = require('HID');
+var HID = require('node-hid');
 
 // buzzer protocol info: http://www.developerfusion.com/article/84338/making-usb-c-friendly/
 

--- a/src/powermate.js
+++ b/src/powermate.js
@@ -6,7 +6,7 @@
 // to the PowerMate contains zero in the first byte and the brightness
 // of the LED in the second byte.
 
-var HID = require('HID');
+var HID = require('node-hid');
 var util = require('util');
 var events = require('events');
 

--- a/src/show-devices.js
+++ b/src/show-devices.js
@@ -1,3 +1,3 @@
-var HID = require('HID');
+var HID = require('node-hid');
 
 console.log('devices:', HID.devices());

--- a/src/test-ps3.js
+++ b/src/test-ps3.js
@@ -1,4 +1,4 @@
-var HID = require('HID');
+var HID = require('node-hid');
 var REPL = require('repl');
 
 var repl = REPL.start('node-hid> ');


### PR DESCRIPTION
Should fix issue https://github.com/hanshuebner/node-hid/issues/22

Unfortunately I had to change require statements from 

`var HID = require('HID');`
 to 

`var HID = require('node-hid');`

An alternative method would be to change the name in package.json to HID.
