### PR TITLE
Cast Work Done Callback

### DIFF
--- a/src/HID.cc
+++ b/src/HID.cc
@@ -245,7 +245,7 @@ HID::read(const Arguments& args)
   req->data = new ReceiveIOCB(hid,
                              Persistent<Object>::New(Local<Object>::Cast(args.This())),
                              Persistent<Function>::New(Local<Function>::Cast(args[0])));
-  uv_queue_work(uv_default_loop(), req, recvAsync, recvAsyncDone);
+  uv_queue_work(uv_default_loop(), req, recvAsync, (uv_after_work_cb)recvAsyncDone);
 
   return Undefined();
 }


### PR DESCRIPTION
For node >= v0.9.4 compat, explicitly cast the after work callback function to `uv_after_work_cb`

Fixes #32

As per the official [Example](https://github.com/rbranson/node-ffi/commit/fdeff41ae8b1cca31d4707d7b61253c45181b8fa)
