### PR TITLE
change requires to be relative

### DIFF
--- a/src/buzzers.js
+++ b/src/buzzers.js
@@ -2,7 +2,7 @@
 
 var util = require('util');
 var events = require('events');
-var HID = require('node-hid');
+var HID = require('../');
 
 // buzzer protocol info: http://www.developerfusion.com/article/84338/making-usb-c-friendly/
 

--- a/src/powermate.js
+++ b/src/powermate.js
@@ -6,7 +6,7 @@
 // to the PowerMate contains zero in the first byte and the brightness
 // of the LED in the second byte.
 
-var HID = require('node-hid');
+var HID = require('../');
 var util = require('util');
 var events = require('events');
 

--- a/src/show-devices.js
+++ b/src/show-devices.js
@@ -1,3 +1,3 @@
-var HID = require('node-hid');
+var HID = require('../');
 
 console.log('devices:', HID.devices());

--- a/src/test-ps3.js
+++ b/src/test-ps3.js
@@ -1,4 +1,4 @@
-var HID = require('node-hid');
+var HID = require('../');
 var REPL = require('repl');
 
 var repl = REPL.start('node-hid> ');


### PR DESCRIPTION
modules are always `required` relative to their path on the filesystem, so this will make all scripts in `src/` work even if `node-hid` is not installed globally.  fixes #44
