### PR TITLE
Fixes issue #75

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "type": "git",
         "url": "git://github.com/hanshuebner/node-hid.git"
     },
-    "bundleDependencies": [ "hidapi" ],
     "scripts": {
         "preupdate": "sh get-hidapi.sh",
         "preinstall": "sh get-hidapi.sh",


### PR DESCRIPTION
The `hidapi` does not exist as an npm module, which was causing npm to fail on install.
