### PR TITLE
Added usagePage and usage fields to output of HID.devices()

### DIFF
--- a/src/HID.cc
+++ b/src/HID.cc
@@ -481,6 +481,8 @@ HID::devices(const Arguments& args)
     }
     deviceInfo->Set(String::NewSymbol("release"), Integer::New(dev->release_number));
     deviceInfo->Set(String::NewSymbol("interface"), Integer::New(dev->interface_number));
+    deviceInfo->Set(String::NewSymbol("usagePage"), Integer::New(dev->usage_page));
+    deviceInfo->Set(String::NewSymbol("usage"), Integer::New(dev->usage));
     retval->Set(count++, deviceInfo);
   }
   hid_free_enumeration(devs);


### PR DESCRIPTION
According to hidapi, it works for Mac/Windows only, but still it is useful.
Btw, there's a [PR](https://github.com/signal11/hidapi/pull/6) to make it work on linux too.
