### PR TITLE
Convert standard v8 calls into NAN macros for node v0.11 compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -99,6 +99,9 @@
           }
         }]
       ],
+      "include_dirs" : [
+        "<!(node -e \"require('nan')\")"
+      ],
       'cflags!': ['-ansi', '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
       'cflags': ['-g', '-exceptions'],

--- a/package.json
+++ b/package.json
@@ -1,29 +1,31 @@
 {
-    "name": "node-hid",
-    "description": "USB HID device access library",
-    "version": "0.3.2",
-    "author": {
-        "name": "Hans Hübner",
-        "email": "hans.huebner@gmail.com",
-        "url": "https://github.com/hanshuebner"
-    },
-    "contributors": [
-        "Blake Miner <miner.blake@gmail.com>"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/hanshuebner/node-hid.git"
-    },
-    "scripts": {
-        "preupdate": "sh get-hidapi.sh",
-        "preinstall": "sh get-hidapi.sh",
-        "install": "sh install.sh"
-    },
-    "main": "./index.js",
-    "engines": {
-        "node": ">=0.8.0"
-    },
-    "license": "MIT/X11",
-    "dependencies": { },
-    "devDependencies": {}
+  "name": "node-hid",
+  "description": "USB HID device access library",
+  "version": "0.3.2",
+  "author": {
+    "name": "Hans Hübner",
+    "email": "hans.huebner@gmail.com",
+    "url": "https://github.com/hanshuebner"
+  },
+  "contributors": [
+    "Blake Miner <miner.blake@gmail.com>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/hanshuebner/node-hid.git"
+  },
+  "scripts": {
+    "preupdate": "sh get-hidapi.sh",
+    "preinstall": "sh get-hidapi.sh",
+    "install": "sh install.sh"
+  },
+  "main": "./index.js",
+  "engines": {
+    "node": ">=0.8.0"
+  },
+  "license": "MIT/X11",
+  "dependencies": {
+    "nan": "^1.4.1"
+  },
+  "devDependencies": {}
 }

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -27,8 +27,8 @@
 
 #include <stdlib.h>
 
-#include <v8.h>
 #include <node.h>
+#include <nan.h>
 #include <node_buffer.h>
 
 #include <hidapi.h>
@@ -47,7 +47,7 @@ public:
   JSException(const string& text) : _message(text) {}
   virtual ~JSException() {}
   virtual const string message() const { return _message; }
-  virtual Handle<Value> asV8Exception() const { return ThrowException(String::New(message().c_str())); }
+  virtual _NAN_METHOD_RETURN_TYPE asV8Exception() const { return NanThrowError(NanNew<String>(message().c_str())); }
 
 protected:
   string _message;
@@ -58,7 +58,7 @@ class HID
 {
 public:
   static void Initialize(Handle<Object> target);
-  static Handle<Value> devices(const Arguments& args);
+  static NAN_METHOD(devices);
 
   typedef vector<unsigned char> databuf_t;
 
@@ -73,42 +73,77 @@ private:
   HID(const char* path);
   ~HID() { close(); }
 
-  static Handle<Value> New(const Arguments& args);
-  static Handle<Value> read(const Arguments& args);
-  static Handle<Value> write(const Arguments& args);
-  static Handle<Value> close(const Arguments& args);
-  static Handle<Value> setNonBlocking(const Arguments& args);
-  static Handle<Value> getFeatureReport(const Arguments& args);
+  static NAN_METHOD(New);
+  static NAN_METHOD(read);
+  static NAN_METHOD(write);
+  static NAN_METHOD(close);
+  static NAN_METHOD(setNonBlocking);
+  static NAN_METHOD(getFeatureReport);
 
-  static Handle<Value> sendFeatureReport(const Arguments& args);
+  static NAN_METHOD(sendFeatureReport);
 
-
-  static void recvAsync(uv_work_t* req);
-  static void recvAsyncDone(uv_work_t* req);
-
-  struct ReceiveIOCB {
-    ReceiveIOCB(HID* hid, Persistent<Object> this_, Persistent<Function> callback)
-      : _hid(hid),
-        _this(this_),
-        _callback(callback),
+  class ReceiveWorker :
+    public NanAsyncWorker
+  {
+  public:
+	ReceiveWorker(HID* hid, NanCallback *callback)
+      : NanAsyncWorker(callback),
+	    _hidHandle(hid->_hidHandle),
         _error(0)
     {}
 
-    ~ReceiveIOCB()
+    ~ReceiveWorker()
     {
       if (_error) {
         delete _error;
       }
     }
+	
+	void
+	Execute()
+	{
+		unsigned char buf[1024];
+		int len = hid_read(_hidHandle, buf, sizeof buf);
+		if (len < 0) {
+			_error = new JSException("could not read from HID device");
+		}
+		else {
+			_data = vector<unsigned char>(buf, buf + len);
+		}
+	}
 
-    HID* _hid;
-    Persistent<Object> _this;
-    Persistent<Function> _callback;
+	void
+	HandleOKCallback()
+	{
+	  NanScope();
+
+	  //Get "fast" node Buffer constructor
+	  Local<Function> nodeBufConstructor = Local<Function>::Cast(
+		NanGetCurrentContext()->Global()->Get(NanNew<String>("Buffer"))
+	  );
+
+	  //Construct a new Buffer
+	  Handle<Value> nodeBufferArgs[1] = { NanNew<Integer>(_data.size()) };
+	  Local<Object> buf = nodeBufConstructor->NewInstance(1, nodeBufferArgs);
+	  char* data = Buffer::Data(buf);
+	  int j = 0;
+	  for (vector<unsigned char>::const_iterator k = _data.begin(); k != _data.end(); k++) {
+		  data[j++] = *k;
+	  }
+
+	  Local<Value> argv[] = {
+		  NanNull(),
+		  buf
+	  };
+
+	  callback->Call(2, argv);
+	}
+
+  private:
+    hid_device* _hidHandle;
     JSException* _error;
     vector<unsigned char> _data;
   };
-
-  void readResultsToJSCallbackArguments(ReceiveIOCB* iocb, Local<Value> argv[]);
 
   hid_device* _hidHandle;
 };
@@ -173,100 +208,32 @@ HID::write(const databuf_t& message)
   }
 }
 
-void
-HID::recvAsync(uv_work_t* req)
+NAN_METHOD(HID::read)
 {
-  ReceiveIOCB* iocb = static_cast<ReceiveIOCB*>(req->data);
-  HID* hid = iocb->_hid;
+  NanScope();
+  Persistent<Object> self;
 
-  unsigned char buf[1024];
-  int len = hid_read(hid->_hidHandle, buf, sizeof buf);
-  if (len < 0) {
-    iocb->_error = new JSException("could not read from HID device");
-  } else {
-    iocb->_data = vector<unsigned char>(buf, buf + len);
-  }
-}
-
-void
-HID::readResultsToJSCallbackArguments(ReceiveIOCB* iocb, Local<Value> argv[])
-{
-  if (iocb->_error) {
-    argv[0] = Exception::Error(String::New(iocb->_error->message().c_str()));
-  } else {
-    const vector<unsigned char>& message = iocb->_data;
-    //Get "fast" node Buffer constructor
-    Local<Function> nodeBufConstructor = Local<Function>::Cast(
-      Context::GetCurrent()->Global()->Get(String::New("Buffer") )
-    );
-    //Construct a new Buffer
-    Handle<Value> nodeBufferArgs[1] = { Integer::New(message.size()) };
-    Local<Object> buf = nodeBufConstructor->NewInstance(1, nodeBufferArgs);
-    char* data = Buffer::Data(buf);
-    int j = 0;
-    for (vector<unsigned char>::const_iterator k = message.begin(); k != message.end(); k++) {
-      data[j++] = *k;
-    }
-    argv[1] = buf;
-  }
-}
-
-void
-HID::recvAsyncDone(uv_work_t* req)
-{
-  HandleScope scope;
-  ReceiveIOCB* iocb = static_cast<ReceiveIOCB*>(req->data);
-
-  Local<Value> argv[2];
-  argv[0] = *Undefined();
-  argv[1] = *Undefined();
-
-  iocb->_hid->readResultsToJSCallbackArguments(iocb, argv);
-  iocb->_hid->Unref();
-
-  TryCatch tryCatch;
-  iocb->_callback->Call(iocb->_this, 2, argv);
-
-  if (tryCatch.HasCaught()) {
-    FatalException(tryCatch);
-  }
-
-  iocb->_this.Dispose();
-  iocb->_callback.Dispose();
-
-  delete iocb;
-}
-
-Handle<Value>
-HID::read(const Arguments& args)
-{
-  HandleScope scope;
+  NanAssignPersistent(self, Local<Object>::Cast(args.This()));
 
   if (args.Length() != 1
       || !args[0]->IsFunction()) {
-    return ThrowException(String::New("need one callback function argument in read"));
+    return NanThrowError(NanNew<String>("need one callback function argument in read"));
   }
 
   HID* hid = ObjectWrap::Unwrap<HID>(args.This());
-  hid->Ref();
 
-  uv_work_t* req = new uv_work_t;
-  req->data = new ReceiveIOCB(hid,
-                             Persistent<Object>::New(Local<Object>::Cast(args.This())),
-                             Persistent<Function>::New(Local<Function>::Cast(args[0])));
-  uv_queue_work(uv_default_loop(), req, recvAsync, (uv_after_work_cb)recvAsyncDone);
+  NanAsyncQueueWorker(new ReceiveWorker(hid, new NanCallback(args[0].As<Function>())));
 
-  return Undefined();
+  NanReturnUndefined();
 }
 
-Handle<Value>
-HID::getFeatureReport(const Arguments& args)
+NAN_METHOD(HID::getFeatureReport)
 {
-  HandleScope scope;
+  NanScope();
 
   if (args.Length() != 2
       || args[1]->ToUint32()->Value() == 0) {
-    return ThrowException(String::New("need report ID and non-zero length parameter in getFeatureReport"));
+    return NanThrowError(NanNew<String>("need report ID and non-zero length parameter in getFeatureReport"));
   }
 
   const uint8_t reportId = args[0]->ToUint32()->Value();
@@ -280,25 +247,24 @@ HID::getFeatureReport(const Arguments& args)
 
   if (returnedLength == -1) {
     delete[] buf;
-    return ThrowException(String::New("could not get feature report from device"));
+    return NanThrowError(NanNew<String>("could not get feature report from device"));
   }
-  Local<Array> retval = Array::New();
+  Local<Array> retval = NanNew<Array>();
 
   for (int i = 0; i < returnedLength; i++) {
-    retval->Set(i, Integer::New(buf[i]));
+    retval->Set(i, NanNew<Integer>(buf[i]));
   }
   delete[] buf;
-  return retval;
+  NanReturnValue(retval);
 }
 
 
-Handle<Value>
-HID::sendFeatureReport(const Arguments& args)
+NAN_METHOD(HID::sendFeatureReport)
 {
-  HandleScope scope;
+  NanScope();
 
   if (args.Length() != 1){
-    return ThrowException(String::New("need report (including id in first byte) only in sendFeatureReport"));
+    return NanThrowError(NanNew<String>("need report (including id in first byte) only in sendFeatureReport"));
   }
 
 
@@ -324,27 +290,23 @@ HID::sendFeatureReport(const Arguments& args)
   int returnedLength = hid_send_feature_report(hid->_hidHandle, buf, message.size());
   delete[] buf;
   if (returnedLength == -1) { // Not sure if there would ever be a valid return value of 0. 
-    return ThrowException(String::New("could not send feature report to device"));
+    return NanThrowError(NanNew<String>("could not send feature report to device"));
   }
 
-  return Integer::New(returnedLength);
+  NanReturnValue(NanNew<Integer>(returnedLength));
 }
 
-
-
-
-Handle<Value>
-HID::New(const Arguments& args)
+NAN_METHOD(HID::New)
 {
   if (!args.IsConstructCall()) {
-    return ThrowException(String::New("HID function can only be used as a constructor"));
+    return NanThrowError(NanNew<String>("HID function can only be used as a constructor"));
   }
 
   if (args.Length() < 1) {
-    return ThrowException(String::New("HID constructor requires at least one argument"));
+    return NanThrowError(NanNew<String>("HID constructor requires at least one argument"));
   }
 
-  HandleScope scope;
+  NanScope();
 
   try {
     HID* hid;
@@ -362,49 +324,46 @@ HID::New(const Arguments& args)
       hid = new HID(vendorId, productId, serialPointer);
     }
     hid->Wrap(args.This());
-    return args.This();
+	NanReturnValue(args.This());
   }
   catch (const JSException& e) {
     return e.asV8Exception();
   }
 }
 
-Handle<Value>
-HID::close(const Arguments& args)
+NAN_METHOD(HID::close)
 {
   try {
     HID* hid = ObjectWrap::Unwrap<HID>(args.This());
     hid->close();
-    return Undefined();
+    NanReturnUndefined();
   }
   catch (const JSException& e) {
     return e.asV8Exception();
   }
 }
 
-Handle<Value>
-HID::setNonBlocking(const Arguments& args)
+NAN_METHOD(HID::setNonBlocking)
 {
   if (args.Length() != 1) {
-    return ThrowException(String::New("Expecting a 1 to enable, 0 to disable as the first argument."));
+    return NanThrowError(NanNew<String>("Expecting a 1 to enable, 0 to disable as the first argument."));
   }
   int blockStatus = 0;
   blockStatus = args[0]->Int32Value();
   try {
     HID* hid = ObjectWrap::Unwrap<HID>(args.This());
     hid->setNonBlocking(blockStatus);
-    return Undefined();
+    NanReturnUndefined();
   }
   catch (const JSException& e) {
     return e.asV8Exception();
   }
 }
 
-Handle<Value>
-HID::write(const Arguments& args)
+NAN_METHOD(HID::write)
 {
   if (args.Length() != 1) {
-    return ThrowException(String::New("HID write requires one argument"));
+    return NanThrowError(NanNew<String>("HID write requires one argument"));
   }
 
   try {
@@ -420,7 +379,7 @@ HID::write(const Arguments& args)
     }
     hid->write(message);
 
-    return Undefined();
+    NanReturnUndefined();
   }
   catch (const JSException& e) {
     return e.asV8Exception();
@@ -438,9 +397,9 @@ narrow(wchar_t* wide)
   return os.str();
 }
 
-Handle<Value>
-HID::devices(const Arguments& args)
+NAN_METHOD(HID::devices)
 {
+  NanScope();
   int vendorId = 0;
   int productId = 0;
 
@@ -461,39 +420,39 @@ HID::devices(const Arguments& args)
   }
   
   hid_device_info* devs = hid_enumerate(vendorId, productId);
-  Local<Array> retval = Array::New();
+  Local<Array> retval = NanNew<Array>();
   int count = 0;
   for (hid_device_info* dev = devs; dev; dev = dev->next) {
-    Local<Object> deviceInfo = Object::New();
-    deviceInfo->Set(String::NewSymbol("vendorId"), Integer::New(dev->vendor_id));
-    deviceInfo->Set(String::NewSymbol("productId"), Integer::New(dev->product_id));
+    Local<Object> deviceInfo = NanNew<Object>();
+    deviceInfo->Set(NanNew<String>("vendorId"), NanNew<Integer>(dev->vendor_id));
+    deviceInfo->Set(NanNew<String>("productId"), NanNew<Integer>(dev->product_id));
     if (dev->path) {
-      deviceInfo->Set(String::NewSymbol("path"), String::New(dev->path));
+      deviceInfo->Set(NanNew<String>("path"), NanNew<String>(dev->path));
     }
     if (dev->serial_number) {
-      deviceInfo->Set(String::NewSymbol("serialNumber"), String::New(narrow(dev->serial_number).c_str()));
+      deviceInfo->Set(NanNew<String>("serialNumber"), NanNew<String>(narrow(dev->serial_number).c_str()));
     }
     if (dev->manufacturer_string) {
-      deviceInfo->Set(String::NewSymbol("manufacturer"), String::New(narrow(dev->manufacturer_string).c_str()));
+      deviceInfo->Set(NanNew<String>("manufacturer"), NanNew<String>(narrow(dev->manufacturer_string).c_str()));
     }
     if (dev->product_string) {
-      deviceInfo->Set(String::NewSymbol("product"), String::New(narrow(dev->product_string).c_str()));
+      deviceInfo->Set(NanNew<String>("product"), NanNew<String>(narrow(dev->product_string).c_str()));
     }
-    deviceInfo->Set(String::NewSymbol("release"), Integer::New(dev->release_number));
-    deviceInfo->Set(String::NewSymbol("interface"), Integer::New(dev->interface_number));
-    deviceInfo->Set(String::NewSymbol("usagePage"), Integer::New(dev->usage_page));
-    deviceInfo->Set(String::NewSymbol("usage"), Integer::New(dev->usage));
+    deviceInfo->Set(NanNew<String>("release"), NanNew<Integer>(dev->release_number));
+    deviceInfo->Set(NanNew<String>("interface"), NanNew<Integer>(dev->interface_number));
+    deviceInfo->Set(NanNew<String>("usagePage"), NanNew<Integer>(dev->usage_page));
+    deviceInfo->Set(NanNew<String>("usage"), NanNew<Integer>(dev->usage));
     retval->Set(count++, deviceInfo);
   }
   hid_free_enumeration(devs);
-  return retval;
+  NanReturnValue(retval);
 }
 
 static void
 deinitialize(void*)
 {
   if (hid_exit()) {
-    cerr << "cannot initialize hidapi (hid_init failed)" << endl;
+    cerr << "cannot deinitialize hidapi (hid_exit failed)" << endl;
     abort();
   }
 }
@@ -505,14 +464,14 @@ HID::Initialize(Handle<Object> target)
     cerr << "cannot initialize hidapi (hid_init failed)" << endl;
     abort();
   }
-
+  
   node::AtExit(deinitialize, 0);
 
-  HandleScope scope;
+  NanScope();
 
-  Local<FunctionTemplate> hidTemplate = FunctionTemplate::New(HID::New);
+  Local<FunctionTemplate> hidTemplate = NanNew<FunctionTemplate>(HID::New);
   hidTemplate->InstanceTemplate()->SetInternalFieldCount(1);
-  hidTemplate->SetClassName(String::New("HID"));
+  hidTemplate->SetClassName(NanNew<String>("HID"));
 
   NODE_SET_PROTOTYPE_METHOD(hidTemplate, "close", close);
   NODE_SET_PROTOTYPE_METHOD(hidTemplate, "read", read);
@@ -521,9 +480,8 @@ HID::Initialize(Handle<Object> target)
   NODE_SET_PROTOTYPE_METHOD(hidTemplate, "sendFeatureReport", sendFeatureReport);
   NODE_SET_PROTOTYPE_METHOD(hidTemplate, "setNonBlocking", setNonBlocking);
 
-  target->Set(String::NewSymbol("HID"), hidTemplate->GetFunction());
-
-  target->Set(String::NewSymbol("devices"), FunctionTemplate::New(HID::devices)->GetFunction());
+  target->Set(NanNew<String>("HID"), hidTemplate->GetFunction());
+  target->Set(NanNew<String>("devices"), NanNew<FunctionTemplate>(HID::devices)->GetFunction());
 }
 
 
@@ -531,8 +489,7 @@ extern "C" {
   
   static void init (Handle<Object> target)
   {
-    HandleScope handleScope;
-    
+    NanScope();
     HID::Initialize(target);
   }
 


### PR DESCRIPTION
Addresses #82, as the latest node-webkit uses node v0.11.
This has been tested on Windows 7 x64 and a clean Linux Mint VM.