### PR TITLE
[FYI] atom-shell compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
-hidapi
 build
 node_modules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hidapi"]
+	path = hidapi
+	url = https://github.com/signal11/hidapi.git

--- a/binding.gyp
+++ b/binding.gyp
@@ -39,7 +39,8 @@
       ],
       'direct_dependent_settings': {
         'include_dirs': [
-          'hidapi/hidapi'
+          'hidapi/hidapi',
+          "<!(node -e \"require('nan')\")"
         ]
       },
       'include_dirs': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -39,8 +39,7 @@
       ],
       'direct_dependent_settings': {
         'include_dirs': [
-          'hidapi/hidapi',
-          "<!(node -e \"require('nan')\")"
+          'hidapi/hidapi'
         ]
       },
       'include_dirs': [

--- a/get-hidapi.sh
+++ b/get-hidapi.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-if [ -d hidapi ]
-then
-    cd hidapi
-    git pull
-else
-    git clone https://github.com/signal11/hidapi.git
-fi

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "hidapi"
   ],
   "scripts": {
-    "preinstall": "git submodule update --init",
-    "install": "node-gyp rebuild install"
+    "prepublish": "git submodule update --init"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "hidapi"
   ],
   "scripts": {
-    "preinstall" : "git submodule update --init && node-gyp rebuild install"
+    "preinstall": "git submodule update --init",
+    "install": "node-gyp rebuild install"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hidapi"
   ],
   "scripts": {
-    "prepublish" : "git submodule update --init"
+    "preinstall" : "git submodule update --init && node-gyp rebuild"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hidapi"
   ],
   "scripts": {
-    "preinstall" : "git submodule update --init && node-gyp rebuild"
+    "preinstall" : "git submodule update --init && node-gyp rebuild install"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hidapi"
   ],
   "scripts": {
-    "preinstall" : "git submodule update --init && node-gyp rebuild"
+    "prepublish" : "git submodule update --init"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "type": "git",
     "url": "git://github.com/hanshuebner/node-hid.git"
   },
-  "scripts": {
-    "prepublish": "sh get-hidapi.sh"
-  },
+  "scripts": {},
   "main": "./index.js",
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "type": "git",
     "url": "git://github.com/hanshuebner/node-hid.git"
   },
-  "bundleDependencies": [
-    "hidapi"
-  ],
   "scripts": {
     "prepublish": "git submodule update --init"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT/X11",
   "dependencies": {
-    "nan": "^1.5.1"
+    "nan": "^1.2.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "type": "git",
     "url": "git://github.com/hanshuebner/node-hid.git"
   },
-  "scripts": {},
+  "bundleDependencies": [
+    "hidapi"
+  ],
+  "scripts": {
+    "preinstall" : "git submodule update --init && node-gyp rebuild"
+  },
   "main": "./index.js",
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "url": "git://github.com/hanshuebner/node-hid.git"
   },
   "scripts": {
-    "preupdate": "sh get-hidapi.sh",
-    "preinstall": "sh get-hidapi.sh"
+    "prepublish": "sh get-hidapi.sh"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
   },
   "scripts": {
     "preupdate": "sh get-hidapi.sh",
-    "preinstall": "sh get-hidapi.sh",
-    "install": "sh install.sh",
-    "install-nw": "sh install-nw.sh"
+    "preinstall": "sh get-hidapi.sh"
   },
   "main": "./index.js",
   "engines": {

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -200,7 +200,7 @@ HID::readResultsToJSCallbackArguments(ReceiveIOCB* iocb, Local<Value> argv[])
       NanGetCurrentContext()->Global()->Get(NanNew<String>("Buffer") )
     );
     //Construct a new Buffer
-    Handle<Value> nodeBufferArgs[1] = { NanNew<Integer>(message.size()) };
+    Handle<Value> nodeBufferArgs[1] = { NanNew<Integer>((uint32_t)message.size()) };
     Local<Object> buf = nodeBufConstructor->NewInstance(1, nodeBufferArgs);
     char* data = Buffer::Data(buf);
     int j = 0;

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -48,7 +48,7 @@ public:
   JSException(const string& text) : _message(text) {}
   virtual ~JSException() {}
   virtual const string message() const { return _message; }
-  virtual void throwAsV8Exception() const { NanThrowError(message().c_str()); }
+  virtual void asV8Exception() const { NanThrowError(message().c_str()); }
 
 protected:
   string _message;
@@ -200,7 +200,7 @@ HID::readResultsToJSCallbackArguments(ReceiveIOCB* iocb, Local<Value> argv[])
       NanGetCurrentContext()->Global()->Get(NanNew<String>("Buffer") )
     );
     //Construct a new Buffer
-    Handle<Value> nodeBufferArgs[1] = { NanNew<Integer>((unsigned int) message.size()) };
+    Handle<Value> nodeBufferArgs[1] = { NanNew<Integer>(message.size()) };
     Local<Object> buf = nodeBufConstructor->NewInstance(1, nodeBufferArgs);
     char* data = Buffer::Data(buf);
     int j = 0;
@@ -358,8 +358,7 @@ NAN_METHOD(HID::New)
     NanReturnValue(args.This());
   }
   catch (const JSException& e) {
-    e.throwAsV8Exception();
-    NanReturnUndefined(); // make the compiler happy
+    e.asV8Exception();
   }
 }
 
@@ -373,8 +372,7 @@ NAN_METHOD(HID::close)
     NanReturnUndefined();
   }
   catch (const JSException& e) {
-    e.throwAsV8Exception();
-    NanReturnUndefined();
+    e.asV8Exception();
   }
 }
 
@@ -393,8 +391,7 @@ NAN_METHOD(HID::setNonBlocking)
     NanReturnUndefined();
   }
   catch (const JSException& e) {
-    e.throwAsV8Exception();
-    NanReturnUndefined();
+    e.asV8Exception();
   }
 }
 
@@ -422,8 +419,7 @@ NAN_METHOD(HID::write)
     NanReturnUndefined();
   }
   catch (const JSException& e) {
-    e.throwAsV8Exception();
-    NanReturnUndefined();
+    e.asV8Exception();
   }
 }
 
@@ -458,7 +454,7 @@ NAN_METHOD(HID::devices)
     }
   }
   catch (JSException& e) {
-    e.throwAsV8Exception();
+    e.asV8Exception();
   }
   
   hid_device_info* devs = hid_enumerate(vendorId, productId);
@@ -482,8 +478,6 @@ NAN_METHOD(HID::devices)
     }
     deviceInfo->Set(NanNew<String>("release"), NanNew<Integer>(dev->release_number));
     deviceInfo->Set(NanNew<String>("interface"), NanNew<Integer>(dev->interface_number));
-    deviceInfo->Set(NanNew<String>("usagePage"), NanNew<Integer>(dev->usage_page));
-    deviceInfo->Set(NanNew<String>("usage"), NanNew<Integer>(dev->usage));
     retval->Set(count++, deviceInfo);
   }
   hid_free_enumeration(devs);


### PR DESCRIPTION
This would almost be better as an issue since this code is a bit of a mess, but here's how I've managed to get this library compiling for atom-shell.

Pre-requisites:

- node v0.10.36
- atom-package-manager@0.101.0
- atom-shell-v0.17.2

Yes…these are all really old versions. Maybe with https://github.com/node-hid/node-hid/issues/90 fixed it could run on latest with the actual changes here.

The main changes here are getting rid of the install.sh shell script, which interferes with how `apm` would normally reconfigure the environment for a proper build. Instead hidapi is a git submodule, and the gyp file gets done directly.

For this setup to work, there was some issue with npm where this package had to be *packaged* rather than installed via a repo link or something. [I may just be cargo-culting at this point, but now when I add `"node-hid": "https://github.com/natevw/node-hid/releases/download/0.3.2/node-hid-0.3.2.tgz"` to my package.json it the main thing is that it builds under atom-shell and I left it at that…]

I've also fixed a compilation bug with "error: call to 'New' is ambiguous", that should probably be its own PR or something but I don't know under what wider circumstances it's needed.