### PR TITLE
Seemingly compatible with node 0.12.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
-hidapi
 build
 node_modules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hidapi"]
+	path = hidapi
+	url = https://github.com/signal11/hidapi.git

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
 
 ### Compile from source on Linux or OSX
 
-Use npm to execute all installation steps:
+To develop locally you'll need the following commands:
 
 ```
-npm install
+git submodule update --init   # done automatically on publish, but you'll need it locally
+npm install       # rebuilds the module
 ```
 
 ### Compile from source on Windows

--- a/binding.gyp
+++ b/binding.gyp
@@ -39,7 +39,8 @@
       ],
       'direct_dependent_settings': {
         'include_dirs': [
-          'hidapi/hidapi'
+          'hidapi/hidapi',
+          "<!(node -e \"require('nan')\")"
         ]
       },
       'include_dirs': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -39,8 +39,7 @@
       ],
       'direct_dependent_settings': {
         'include_dirs': [
-          'hidapi/hidapi',
-          "<!(node -e \"require('nan')\")"
+          'hidapi/hidapi'
         ]
       },
       'include_dirs': [

--- a/get-hidapi.sh
+++ b/get-hidapi.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-if [ -d hidapi ]
-then
-    cd hidapi
-    git pull
-else
-    git clone https://github.com/signal11/hidapi.git
-fi

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "hidapi"
   ],
   "scripts": {
-    "preinstall": "git submodule update --init",
-    "install": "node-gyp rebuild install"
+    "prepublish": "git submodule update --init"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "hidapi"
   ],
   "scripts": {
-    "preinstall" : "git submodule update --init && node-gyp rebuild install"
+    "preinstall": "git submodule update --init",
+    "install": "node-gyp rebuild install"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hidapi"
   ],
   "scripts": {
-    "prepublish" : "git submodule update --init"
+    "preinstall" : "git submodule update --init && node-gyp rebuild"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hidapi"
   ],
   "scripts": {
-    "preinstall" : "git submodule update --init && node-gyp rebuild"
+    "preinstall" : "git submodule update --init && node-gyp rebuild install"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hidapi"
   ],
   "scripts": {
-    "preinstall" : "git submodule update --init && node-gyp rebuild"
+    "prepublish" : "git submodule update --init"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "type": "git",
     "url": "git://github.com/hanshuebner/node-hid.git"
   },
-  "scripts": {
-    "prepublish": "sh get-hidapi.sh"
-  },
+  "scripts": {},
   "main": "./index.js",
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "type": "git",
     "url": "git://github.com/hanshuebner/node-hid.git"
   },
-  "bundleDependencies": [
-    "hidapi"
-  ],
   "scripts": {
     "prepublish": "git submodule update --init"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT/X11",
   "dependencies": {
-    "nan": "^1.5.1"
+    "nan": "^1.2.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "type": "git",
     "url": "git://github.com/hanshuebner/node-hid.git"
   },
-  "scripts": {},
+  "bundleDependencies": [
+    "hidapi"
+  ],
+  "scripts": {
+    "preinstall" : "git submodule update --init && node-gyp rebuild"
+  },
   "main": "./index.js",
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "url": "git://github.com/hanshuebner/node-hid.git"
   },
   "scripts": {
-    "preupdate": "sh get-hidapi.sh",
-    "preinstall": "sh get-hidapi.sh"
+    "prepublish": "sh get-hidapi.sh"
   },
   "main": "./index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
   },
   "scripts": {
     "preupdate": "sh get-hidapi.sh",
-    "preinstall": "sh get-hidapi.sh",
-    "install": "sh install.sh",
-    "install-nw": "sh install-nw.sh"
+    "preinstall": "sh get-hidapi.sh"
   },
   "main": "./index.js",
   "engines": {

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -200,7 +200,7 @@ HID::readResultsToJSCallbackArguments(ReceiveIOCB* iocb, Local<Value> argv[])
       NanGetCurrentContext()->Global()->Get(NanNew<String>("Buffer") )
     );
     //Construct a new Buffer
-    Handle<Value> nodeBufferArgs[1] = { NanNew<Integer>(message.size()) };
+    Handle<Value> nodeBufferArgs[1] = { NanNew<Integer>((uint32_t)message.size()) };
     Local<Object> buf = nodeBufConstructor->NewInstance(1, nodeBufferArgs);
     char* data = Buffer::Data(buf);
     int j = 0;

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -48,7 +48,7 @@ public:
   JSException(const string& text) : _message(text) {}
   virtual ~JSException() {}
   virtual const string message() const { return _message; }
-  virtual void throwAsV8Exception() const { NanThrowError(message().c_str()); }
+  virtual void asV8Exception() const { NanThrowError(message().c_str()); }
 
 protected:
   string _message;
@@ -200,7 +200,7 @@ HID::readResultsToJSCallbackArguments(ReceiveIOCB* iocb, Local<Value> argv[])
       NanGetCurrentContext()->Global()->Get(NanNew<String>("Buffer") )
     );
     //Construct a new Buffer
-    Handle<Value> nodeBufferArgs[1] = { NanNew<Integer>((unsigned int) message.size()) };
+    Handle<Value> nodeBufferArgs[1] = { NanNew<Integer>(message.size()) };
     Local<Object> buf = nodeBufConstructor->NewInstance(1, nodeBufferArgs);
     char* data = Buffer::Data(buf);
     int j = 0;
@@ -358,8 +358,7 @@ NAN_METHOD(HID::New)
     NanReturnValue(args.This());
   }
   catch (const JSException& e) {
-    e.throwAsV8Exception();
-    NanReturnUndefined(); // make the compiler happy
+    e.asV8Exception();
   }
 }
 
@@ -373,8 +372,7 @@ NAN_METHOD(HID::close)
     NanReturnUndefined();
   }
   catch (const JSException& e) {
-    e.throwAsV8Exception();
-    NanReturnUndefined();
+    e.asV8Exception();
   }
 }
 
@@ -393,8 +391,7 @@ NAN_METHOD(HID::setNonBlocking)
     NanReturnUndefined();
   }
   catch (const JSException& e) {
-    e.throwAsV8Exception();
-    NanReturnUndefined();
+    e.asV8Exception();
   }
 }
 
@@ -422,8 +419,7 @@ NAN_METHOD(HID::write)
     NanReturnUndefined();
   }
   catch (const JSException& e) {
-    e.throwAsV8Exception();
-    NanReturnUndefined();
+    e.asV8Exception();
   }
 }
 
@@ -458,7 +454,7 @@ NAN_METHOD(HID::devices)
     }
   }
   catch (JSException& e) {
-    e.throwAsV8Exception();
+    e.asV8Exception();
   }
   
   hid_device_info* devs = hid_enumerate(vendorId, productId);
@@ -482,8 +478,6 @@ NAN_METHOD(HID::devices)
     }
     deviceInfo->Set(NanNew<String>("release"), NanNew<Integer>(dev->release_number));
     deviceInfo->Set(NanNew<String>("interface"), NanNew<Integer>(dev->interface_number));
-    deviceInfo->Set(NanNew<String>("usagePage"), NanNew<Integer>(dev->usage_page));
-    deviceInfo->Set(NanNew<String>("usage"), NanNew<Integer>(dev->usage));
     retval->Set(count++, deviceInfo);
   }
   hid_free_enumeration(devs);


### PR DESCRIPTION
UPDATE: to test, `npm install https://github.com/natevw/node-hid/releases/download/test-node-12/node-hid-0.3.2.tgz` and run `node -e "console.log(require('node-hid').devices())"` [or follow relevant steps for Electron/node-webkit/??? platform you are interested in].

---

This branch compiles and loads with only warnings under v0.12.2. It's basically some build process simplification (let npm, or more specifically apm and presumably node-webkit's system use the gyp file directly) I've been using for a while (see #92 for original PR), plus @masterakos's fix for #94.

This seems too good to be true — last time I tried there were some more serious V8/libuv/binding-whatever compilation errors. So I don't know if nan has been updated, or node v0.12.2 got a bit more compatible than 0.12.0 was, or if things are just broken more quietly.

But figured I'd post this here in case others want to test too, while I continue to poke at it a bit more myself.