### PR TITLE
Raspberry Pi needs libudev-dev, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,8 @@ binary for you, you will need the following tools:
     * Compilation tools: `apt install build-essential git`
     * gcc-4.8+: `apt install gcc-4.8 g++-4.8 && export CXX=g++-4.8`
     * libusb-1.0-0 w/headers:`sudo apt install libusb-1.0-0 libusb-1.0-0-dev`
-    * libudev-dev: (Fedora only) `yum install libusbx-devel`
+    * libudev-dev: (raspberry pi only) `sudo apt-get install libudev-dev`
+    * libudev-dev: (Fedora only) `yum install libusbx-devel`
 * Mac OS X 10.8+
     * [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)
 * Windows XP, 7, 8, 10


### PR DESCRIPTION
If I don't install `libudev-dev` on raspberry pi stretch, I get:

```text
  CC(target) Release/obj.target/hidapi/hidapi/linux/hid.o
../hidapi/linux/hid.c:44:21: fatal error: libudev.h: No such file or directory
 #include <libudev.h>
```

So `apt-get install libudev-dev` fixed it for me.