### PR TITLE
Improve documentation of usage of HID.devices()

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,9 @@ if(os.platform === 'win32') {
 }
 ```
 
+### HID.devices() is slow
+
+Be very careful with usage of HID.devices() because it is slow and can slow down the read/write that you do in parallel with a device. If you do polling, make sure to not poll it too often and to pause your polling when you need to access a device.
 
 ## Linux notes
 


### PR DESCRIPTION
We recently found a bottleneck in our code because we were using `HID.devices()` too often: we had a watch loop that list devices, pause for 100ms and do it again. The usecase is basically to observe when a device is plugged or unplugged. It was working fine on Mac but definitely not on windows: the fact a polling loop runs in background and if at same time you do read/write with the device makes everything super slow, by an order of about x10 slower. So for instance, we derivate a bitcoin address (with an hardware wallet device) in 300ms but with a background loop it was taking about 5s.
We fixed that by skipping the polling when a device interaction happen and also doing our watch loop way less often (each 1s).

I feel it would have helped us if it was written in the documentation so I hope this will help future users.