### PR TITLE
Allow node-pre-gyp to compile for target platfoms

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
   "bin": {
     "hid-showdevices": "./src/show-devices.js"
   },
+  "binary": {
+    "module_name": "node-hid",
+    "module_path": "./lib/node-hid/",
+    "host": "https://github.com/node-hid/node-hid/releases"
+  },
   "main": "./nodehid.js",
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
I'm building a project from a Linux machine and want to be able to, from my shell script, install node-hid for multiple operating systems.

This change to package.json will allow me to use `node-pre-gyp` to compile node-hid as part of my build process.