### PR TITLE
fix event loop caused crash in Worker

### DIFF
--- a/src/HID.cc
+++ b/src/HID.cc
@@ -252,7 +252,7 @@ NAN_METHOD(HID::read)
 
   uv_work_t* req = new uv_work_t;
   req->data = new ReceiveIOCB(hid, new Nan::Callback(Local<Function>::Cast(info[0])));;
-  uv_queue_work(uv_default_loop(), req, recvAsync, (uv_after_work_cb)recvAsyncDone);
+  uv_queue_work(Nan::GetCurrentEventLoop(), req, recvAsync, (uv_after_work_cb)recvAsyncDone);
 
   return;
 }


### PR DESCRIPTION
Quick fix issue #389 , so add-on could run in Worker above Node version >= 10