### PR TITLE
feat: run async read on std::thread instead of uv threadpool

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
      * [device.close()](#deviceclose)
      * [device.pause()](#devicepause)
      * [device.resume()](#deviceresume)
-     * [device.read(callback)](#devicereadcallback)
      * [device.readSync()](#devicereadsync)
      * [device.readTimeout(time_out)](#devicereadtimeouttime_out)
      * [device.sendFeatureReport(data)](#devicesendfeaturereportdata)
@@ -321,19 +320,22 @@ If no listeners are registered for the `data` event, data will be lost.
 - When a `data` event is registered for this HID device, this method will
 be automatically called.
 
-### `device.read(callback)`
-
-- Low-level function call to initiate an asynchronous read from the device.
-- `callback` is of the form `callback(err, data)`
-
 ### `device.readSync()`
 
 - Return an array of numbers data. If an error occurs, an exception will be thrown.
+
+- This cannot us used while the async read is running
+
+- Note: this will block execution of javascript until the method returns. It is not recommended to use this
 
 ### `device.readTimeout(time_out)`
 
 - `time_out` - timeout in milliseconds
 - Return an array of numbers data. If an error occurs, an exception will be thrown.
+
+- This cannot us used while the async read is running
+
+- Note: this will block execution of javascript until the method returns. It is not recommended to use this
 
 ### `device.sendFeatureReport(data)`
 

--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   "main": "./nodehid.js",
   "binary": {
     "napi_versions": [
-      3
+      4
     ]
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "license": "(MIT OR X11)",
   "dependencies": {
     "bindings": "^1.5.0",
-    "node-addon-api": "^3.0.2",
+    "node-addon-api": "^3.2.1",
     "prebuild-install": "^6.0.0"
   },
   "devDependencies": {

--- a/src/buzzers.js
+++ b/src/buzzers.js
@@ -30,7 +30,7 @@ function BuzzerController(index)
 
     // Initialize buzzers
     this.hid.write([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
-    this.hid.read(this.buzzerData.bind(this));
+    this.hid.on('data', this.buzzerData.bind(this));
 }
 
 util.inherits(BuzzerController, events.EventEmitter);
@@ -48,14 +48,13 @@ BuzzerController.prototype.handleBuzzer = function (buzzerNumber, bits)
     }
 }
 
-BuzzerController.prototype.buzzerData = function (error, data) {
-    console.log('error', error, 'data', data);
+BuzzerController.prototype.buzzerData = function ( data) {
+    console.log('data', data);
     var bits = (data[4] << 16) | (data[3] << 8) | data[2];
     for (var i = 0; i < 4; i++) {
         this.handleBuzzer(i, bits);
     }
     this.oldBits = bits;
-    this.hid.read(this.buzzerData.bind(this));
 }
 
 BuzzerController.prototype.led = function(buzzer, state) {

--- a/src/powermate.js
+++ b/src/powermate.js
@@ -35,7 +35,7 @@ function PowerMate(index)
     this.hid = new HID.HID(powerMates[index].path);
     this.position = 0;
     this.button = 0;
-    this.hid.read(this.interpretData.bind(this));
+    this.hid.on('data', this.interpretData.bind(this))
 }
 
 util.inherits(PowerMate, events.EventEmitter);
@@ -44,7 +44,7 @@ PowerMate.prototype.setLed = function(brightness) {
     this.hid.write([0, brightness]);
 }
 
-PowerMate.prototype.interpretData = function(error, data) {
+PowerMate.prototype.interpretData = function(data) {
     var button = data[0];
     if (button ^ this.button) {
         this.emit(button ? 'buttonDown' : 'buttonUp');
@@ -58,7 +58,6 @@ PowerMate.prototype.interpretData = function(error, data) {
         this.position += delta;
         this.emit('turn', delta, this.position);
     }
-    this.hid.read(this.interpretData.bind(this));
 }
 
 exports.PowerMate = PowerMate;

--- a/src/test-ps3-rumbleled.js
+++ b/src/test-ps3-rumbleled.js
@@ -36,14 +36,11 @@ function setRumbleLed(hidDevice, rumbleL, rumbleR, led_cmd )
     ]);
 }
 
-hid.gotData = function (err, data) {
+hid.on('data', (data) => {
     console.log('got ps3 data', data);
     // map left & right d-pad to rumble, and right action buttons to LEDs
     setRumbleLed( hid, data[15], data[17], data[3]>>3 );
-    this.read(this.gotData.bind(this));
-};
-
-hid.read(hid.gotData.bind(hid));
+})
 
 /*
  * data is 48-byte Buffer with byte values:

--- a/src/test-ps3.js
+++ b/src/test-ps3.js
@@ -6,11 +6,8 @@ var hid = new HID.HID(1356, 616);
 
 console.log('features', hid.getFeatureReport(0xf2, 17));
 
-hid.gotData = function (err, data) {
+hid.on('data', (data) => {
     console.log('got ps3 data', data);
-    this.read(this.gotData.bind(this));
-}
-
-hid.read(hid.gotData.bind(hid));
+})
 
 repl.context.hid = hid;


### PR DESCRIPTION
This resolves the issue with not being able to read from more than 4 devices simultaneously unless `UV_THREADPOOL_SIZE` is increased.
https://github.com/node-hid/node-hid/issues/408

Instead of using the uv-pool to run the reads, a normal c++ thread is started to read from each device when `resume()` is first called or a listener is added. 

I have tried to keep functionality the same, but it is possible there are some subtle differences.
The change ended up being a bit bigger than I was hoping, to get the lifetime of the device to behave the same as before.

One thing that has changed is the removal of:
https://github.com/node-hid/node-hid#devicereadcallback
I could bring it back, but it would behave differently when called for a second time

Some backround reading: https://nodejs.org/en/docs/guides/dont-block-the-event-loop/