### PR TITLE
feat: devicesAsync method to poll for devices in a uv worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
      * [Writing to a device](#writing-to-a-device)
   * [Complete API](#complete-api)
      * [devices = HID.devices()](#devices--hiddevices)
+     * [devices = HID.devicesAsync()](#devices--hiddevicesAsync)
      * [HID.setDriverType(type)](#hidsetdrivertypetype)
      * [device = new HID.HID(path)](#device--new-hidhidpath)
      * [device = new HID.HID(vid,pid)](#device--new-hidhidvidpid)
@@ -275,6 +276,12 @@ number of bytes written + 1.
 ### `devices = HID.devices()`
 
 - Return array listing all connected HID devices
+- This will block program execution for many milliseconds
+
+### `devices = HID.devicesAsync()`
+
+- Return a Promise for an array listing all connected HID devices
+- This is run in the background
 
 ### `HID.setDriverType(type)`
   - Linux only

--- a/nodehid.js
+++ b/nodehid.js
@@ -122,12 +122,18 @@ HID.prototype.resume = function resume() {
     }
 };
 
-function showdevices() {
+function showDevices() {
     loadBinding();
     return binding.devices.apply(HID,arguments);
 }
 
+function showDevicesAsync() {
+    loadBinding();
+    return binding.devicesAsync.apply(HID,arguments);
+}
+
 //Expose API
 exports.HID = HID;
-exports.devices = showdevices;
+exports.devices = showDevices;
+exports.devicesAsync = showDevicesAsync;
 exports.setDriverType = setDriverType;


### PR DESCRIPTION
Allow for async scanning of devices by running the scan in the uv pool.

I don't know if this is safe to do, hidapi does say it isnt thread safe but I don't know if that is related to operations on a single device or for the api in general. If it isnt safe, I can move this and more bits onto a dedicated std::thread so that they can all be async but avoid blocking the main thread. 

So far only tested on linux with libusb backend