### PR TITLE
fix: webpack bundling

### DIFF
--- a/nodehid.js
+++ b/nodehid.js
@@ -16,13 +16,22 @@ function loadBinding() {
         if( os.platform() === 'linux' ) {
             // Linux defaults to hidraw
             if( !driverType || driverType === 'hidraw' ) {
-                binding = require('bindings')('HID_hidraw.node');
+                binding = require('bindings')({
+                    bindings: 'HID_hidraw.node',
+                    module_root: __dirname,
+                });
             } else {
-                binding = require('bindings')('HID.node');
+                binding = require('bindings')({
+                    bindings: 'HID.node',
+                    module_root: __dirname,
+                });
             }
         }
         else {
-            binding = require('bindings')('HID.node');
+            binding = require('bindings')({
+                bindings: 'HID.node',
+                    module_root: __dirname,
+                });
         }
     }
 }


### PR DESCRIPTION
When bundling code with webpack, the paths of files and everything get mangled, resulting in this error: https://github.com/TooTallNate/node-bindings/issues/54

A simple solution for this is to tell bindings where to look with the `module_root` option, rather than making it try to figure it out by generating and parsing a stack trace