### PR TITLE
fix: electron 21 support

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       matrix:

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -129,11 +129,6 @@ void HID::closeHandle()
   }
 }
 
-void deleteArray(const Napi::Env &env, unsigned char *ptr)
-{
-  delete[] ptr;
-}
-
 class ReadWorker : public Napi::AsyncWorker
 {
 public:
@@ -163,8 +158,7 @@ public:
 
   void OnOK() override
   {
-    auto buffer = Napi::Buffer<unsigned char>::New(Env(), buf, len, deleteArray);
-    buf = nullptr; // It is now owned by the buffer
+    auto buffer = Napi::Buffer<unsigned char>::Copy(Env(), buf, len);
     Callback().Call({Env().Null(), buffer});
   }
 


### PR DESCRIPTION
Electron 21 broke the node-api stability guarantee, by disallowing the ability to wrap external pointers https://www.electronjs.org/blog/v8-memory-cage.
Attempts to do so result in a runtime crash:
```
[1084869:0928/110216.575958:ERROR:node_bindings.cc(146)] Fatal error in V8: v8_ArrayBuffer_NewBackingStore When the V8 Sandbox is enabled, ArrayBuffer backing stores must be allocated inside the sandbox address space. Please use an appropriate ArrayBuffer::Allocator to allocate these buffers.
```

This resolves the issue by making a copy of the data when wrapping it in a Buffer. This is additional work and memory allocations, but as hid devices typically dont produce much data (and we cap it at 2048 bytes) I dont expect this to have a notable penalty.

Alternatively, we could allocate the Buffer earlier and perform the read directly into it, but I think that adds more complication as we will need to trim the end off based on how many bytes were read.