### PR TITLE
Fixed Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ number of bytes written + 1.
 
 - `data` - Buffer - the data read from the device
 
-### `device.on('error, function(error) {} )`
+### `device.on('error', function(error) {} )`
 
 - `error` - The error Object emitted
 


### PR DESCRIPTION
Just noticed a Typo :D


device.on('error, function(error) {}  ->  device.on('error', function(error) {} )

