### PR TITLE
Feat/expand getdeviceinfo

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
      * [device.close()](#deviceclose)
      * [device.pause()](#devicepause)
      * [device.resume()](#deviceresume)
-     * [device.read(callback)](#devicereadcallback)
      * [device.readSync()](#devicereadsync)
      * [device.readTimeout(time_out)](#devicereadtimeouttime_out)
      * [device.sendFeatureReport(data)](#devicesendfeaturereportdata)
@@ -321,19 +320,22 @@ If no listeners are registered for the `data` event, data will be lost.
 - When a `data` event is registered for this HID device, this method will
 be automatically called.
 
-### `device.read(callback)`
-
-- Low-level function call to initiate an asynchronous read from the device.
-- `callback` is of the form `callback(err, data)`
-
 ### `device.readSync()`
 
 - Return an array of numbers data. If an error occurs, an exception will be thrown.
+
+- This cannot us used while the async read is running
+
+- Note: this will block execution of javascript until the method returns. It is not recommended to use this
 
 ### `device.readTimeout(time_out)`
 
 - `time_out` - timeout in milliseconds
 - Return an array of numbers data. If an error occurs, an exception will be thrown.
+
+- This cannot us used while the async read is running
+
+- Note: this will block execution of javascript until the method returns. It is not recommended to use this
 
 ### `device.sendFeatureReport(data)`
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
      * [device.readTimeout(time_out)](#devicereadtimeouttime_out)
      * [device.sendFeatureReport(data)](#devicesendfeaturereportdata)
      * [device.getFeatureReport(report_id, report_length)](#devicegetfeaturereportreport_id-report_length)
+     * [device.getFeatureReportBuffer(report_id, report_length)](#devicegetfeaturereportreportbuffer_id-report_length)
      * [device.setNonBlocking(no_block)](#devicesetnonblockingno_block)
   * [General notes:](#general-notes)
      * [Thread safety, Worker threads, Context-aware modules](#thread-safety-worker-threads-context-aware-modules)
@@ -214,7 +215,7 @@ if( deviceInfo ) {
 
 ### Reading from a device
 
-To receive FEATURE reports, use `device.getFeatureReport()`.
+To receive FEATURE reports, use `device.getFeatureReport()` or `device.getFeatureReportBuffer()`.
 
 To receive INPUT reports, use `device.on("data",...)`.
 A `node-hid` device is an EventEmitter.
@@ -238,7 +239,7 @@ var buf = device.getFeatureReport(reportId, reportLength)
 
 Notes:
 - Reads via `device.on("data")` are asynchronous
-- Reads via `device.getFeatureReport()` are synchronous
+- Reads via `device.getFeatureReport()` and `device.getFeatureReportBuffer()` are synchronous
 - To remove an event handler, close the device with `device.close()`
 - When there is not yet a data handler or no data handler exists,
    data is not read at all -- there is no buffer.
@@ -346,6 +347,13 @@ be automatically called.
 
 - `report_id` - HID feature report id to get
 - `report_length` - length of report
+- Returns array of numbers for the response
+
+### `device.getFeatureReportBuffers(report_id, report_length)`
+
+- `report_id` - HID feature report id to get
+- `report_length` - length of report
+- Returns a buffer containing the response
 
 ### `device.setNonBlocking(no_block)`
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@
      * [device.close()](#deviceclose)
      * [device.pause()](#devicepause)
      * [device.resume()](#deviceresume)
+     * [device.read(callback)](#devicereadcallback)
      * [device.readSync()](#devicereadsync)
      * [device.readTimeout(time_out)](#devicereadtimeouttime_out)
      * [device.sendFeatureReport(data)](#devicesendfeaturereportdata)
      * [device.getFeatureReport(report_id, report_length)](#devicegetfeaturereportreport_id-report_length)
-     * [device.getFeatureReportBuffer(report_id, report_length)](#devicegetfeaturereportreportbuffer_id-report_length)
      * [device.setNonBlocking(no_block)](#devicesetnonblockingno_block)
   * [General notes:](#general-notes)
      * [Thread safety, Worker threads, Context-aware modules](#thread-safety-worker-threads-context-aware-modules)
@@ -215,7 +215,7 @@ if( deviceInfo ) {
 
 ### Reading from a device
 
-To receive FEATURE reports, use `device.getFeatureReport()` or `device.getFeatureReportBuffer()`.
+To receive FEATURE reports, use `device.getFeatureReport()`.
 
 To receive INPUT reports, use `device.on("data",...)`.
 A `node-hid` device is an EventEmitter.
@@ -239,7 +239,7 @@ var buf = device.getFeatureReport(reportId, reportLength)
 
 Notes:
 - Reads via `device.on("data")` are asynchronous
-- Reads via `device.getFeatureReport()` and `device.getFeatureReportBuffer()` are synchronous
+- Reads via `device.getFeatureReport()` are synchronous
 - To remove an event handler, close the device with `device.close()`
 - When there is not yet a data handler or no data handler exists,
    data is not read at all -- there is no buffer.
@@ -321,22 +321,19 @@ If no listeners are registered for the `data` event, data will be lost.
 - When a `data` event is registered for this HID device, this method will
 be automatically called.
 
+### `device.read(callback)`
+
+- Low-level function call to initiate an asynchronous read from the device.
+- `callback` is of the form `callback(err, data)`
+
 ### `device.readSync()`
 
 - Return an array of numbers data. If an error occurs, an exception will be thrown.
-
-- This cannot us used while the async read is running
-
-- Note: this will block execution of javascript until the method returns. It is not recommended to use this
 
 ### `device.readTimeout(time_out)`
 
 - `time_out` - timeout in milliseconds
 - Return an array of numbers data. If an error occurs, an exception will be thrown.
-
-- This cannot us used while the async read is running
-
-- Note: this will block execution of javascript until the method returns. It is not recommended to use this
 
 ### `device.sendFeatureReport(data)`
 
@@ -347,13 +344,6 @@ be automatically called.
 
 - `report_id` - HID feature report id to get
 - `report_length` - length of report
-- Returns array of numbers for the response
-
-### `device.getFeatureReportBuffers(report_id, report_length)`
-
-- `report_id` - HID feature report id to get
-- `report_length` - length of report
-- Returns a buffer containing the response
 
 ### `device.setNonBlocking(no_block)`
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,7 @@
                 'src/exports.cc',
                 'src/HID.cc',
                 'src/HIDAsync.cc',
+                'src/devices.cc',
                 'src/read.cc',
                 'src/util.cc'
             ],
@@ -135,6 +136,7 @@
                         'src/exports.cc',
                         'src/HID.cc',
                         'src/HIDAsync.cc',
+                        'src/devices.cc',
                         'src/read.cc',
                         'src/util.cc'
                     ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,7 @@
         {
             'target_name': 'HID',
             'sources': [
+                'src/exports.cc',
                 'src/HID.cc',
                 'src/HIDAsync.cc',
                 'src/read.cc',
@@ -131,6 +132,7 @@
                 {
                     'target_name': 'HID_hidraw',
                     'sources': [
+                        'src/exports.cc',
                         'src/HID.cc',
                         'src/HIDAsync.cc',
                         'src/read.cc',

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
     'targets': [
         {
             'target_name': 'HID',
-            'sources': [ 'src/HID.cc' ],
+            'sources': [ 'src/HID.cc', 'src/HIDAsync.cc' ],
             'dependencies': ['hidapi'],
             'defines': [
                 '_LARGEFILE_SOURCE',
@@ -125,7 +125,7 @@
             'targets': [
                 {
                     'target_name': 'HID_hidraw',
-                    'sources': [ 'src/HID.cc' ],
+                    'sources': [ 'src/HID.cc', 'src/HIDAsync.cc' ],
                     'dependencies': ['hidapi-linux-hidraw'],
                     'defines': [
                         '_LARGEFILE_SOURCE',

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,12 @@
     'targets': [
         {
             'target_name': 'HID',
-            'sources': [ 'src/HID.cc', 'src/HIDAsync.cc' ],
+            'sources': [
+                'src/HID.cc',
+                'src/HIDAsync.cc',
+                'src/read.cc',
+                'src/util.cc'
+            ],
             'dependencies': ['hidapi'],
             'defines': [
                 '_LARGEFILE_SOURCE',
@@ -125,7 +130,12 @@
             'targets': [
                 {
                     'target_name': 'HID_hidraw',
-                    'sources': [ 'src/HID.cc', 'src/HIDAsync.cc' ],
+                    'sources': [
+                        'src/HID.cc',
+                        'src/HIDAsync.cc',
+                        'src/read.cc',
+                        'src/util.cc'
+                    ],
                     'dependencies': ['hidapi-linux-hidraw'],
                     'defines': [
                         '_LARGEFILE_SOURCE',

--- a/nodehid.d.ts
+++ b/nodehid.d.ts
@@ -42,10 +42,6 @@ export function devicesAsync(): Promise<Device[]>
 
 export class HIDAsync extends EventEmitter {
     private constructor()
-
-    static open(path: string): Promise<HIDAsync>
-    static open(vid: number, pid: number): Promise<HIDAsync>
-
     close(): Promise<void>
     pause(): void
     read(time_out?: number | undefined): Promise<Buffer | undefined>
@@ -55,6 +51,9 @@ export class HIDAsync extends EventEmitter {
     write(values: number[] | Buffer): Promise<number>
     setNonBlocking(no_block: boolean): Promise<void>
 }
+
+export function openAsyncHIDDevice(path: string): Promise<HIDAsync>
+export function openAsyncHIDDevice(vid: number, pid: number): Promise<HIDAsync>
 
 export function setDriverType(type: 'hidraw' | 'libusb'): void
 

--- a/nodehid.d.ts
+++ b/nodehid.d.ts
@@ -42,6 +42,10 @@ export function devicesAsync(): Promise<Device[]>
 
 export class HIDAsync extends EventEmitter {
     private constructor()
+
+    static open(path: string): Promise<HIDAsync>
+    static open(vid: number, pid: number): Promise<HIDAsync>
+
     close(): Promise<void>
     pause(): void
     read(time_out?: number | undefined): Promise<Buffer | undefined>
@@ -51,9 +55,6 @@ export class HIDAsync extends EventEmitter {
     write(values: number[] | Buffer): Promise<number>
     setNonBlocking(no_block: boolean): Promise<void>
 }
-
-export function openAsyncHIDDevice(path: string): Promise<HIDAsync>
-export function openAsyncHIDDevice(vid: number, pid: number): Promise<HIDAsync>
 
 export function setDriverType(type: 'hidraw' | 'libusb'): void
 

--- a/nodehid.d.ts
+++ b/nodehid.d.ts
@@ -1,0 +1,59 @@
+// Type definitions for node-hid 1.3
+// Project: https://github.com/node-hid/node-hid#readme
+// Definitions by: Mohamed Hegazy <https://github.com/mhegazy>
+//                 Robert Kiss <https://github.com/ert78gb>
+//                 Rob Moran <https://github.com/thegecko>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { EventEmitter } from 'events'
+
+export interface Device {
+    vendorId: number
+    productId: number
+    path?: string | undefined
+    serialNumber?: string | undefined
+    manufacturer?: string | undefined
+    product?: string | undefined
+    release: number
+    interface: number
+    usagePage?: number | undefined
+    usage?: number | undefined
+}
+
+export class HID extends EventEmitter {
+    constructor(path: string)
+    constructor(vid: number, pid: number)
+    close(): void
+    pause(): void
+    read(callback: (err: any, data: number[]) => void): void
+    readSync(): number[]
+    readTimeout(time_out: number): number[]
+    sendFeatureReport(data: number[] | Buffer): number
+    getFeatureReport(report_id: number, report_length: number): number[]
+    resume(): void
+    write(values: number[] | Buffer): number
+    setNonBlocking(no_block: boolean): void
+}
+export function devices(vid: number, pid: number): Device[]
+export function devices(): Device[]
+
+export function devicesAsync(vid: number, pid: number): Promise<Device[]>
+export function devicesAsync(): Promise<Device[]>
+
+export class HIDAsync extends EventEmitter {
+    private constructor()
+    close(): Promise<void>
+    pause(): void
+    read(time_out?: number | undefined): Promise<Buffer | undefined>
+    sendFeatureReport(data: number[] | Buffer): Promise<number>
+    getFeatureReport(report_id: number, report_length: number): Promise<Buffer>
+    resume(): void
+    write(values: number[] | Buffer): Promise<number>
+    setNonBlocking(no_block: boolean): Promise<void>
+}
+
+export function openAsyncHIDDevice(path: string): Promise<HIDAsync>
+export function openAsyncHIDDevice(vid: number, pid: number): Promise<HIDAsync>
+
+export function setDriverType(type: 'hidraw' | 'libusb'): void
+

--- a/nodehid.js
+++ b/nodehid.js
@@ -121,6 +121,10 @@ class HIDAsync extends EventEmitter {
     constructor(raw) {
         super()
 
+        if (!(raw instanceof binding.HIDAsync)) {
+            throw new Error(`HIDAsync cannot be constructed directly. Use HIDAsync.open() instead`)
+        }
+
         this._raw = raw
 
         /* Now we have `this._raw` Object from which we need to
@@ -145,6 +149,12 @@ class HIDAsync extends EventEmitter {
             if(eventName == "data" && this.listenerCount("data") == 0)
                 process.nextTick(this.pause.bind(this) );
         })
+    }
+
+    static async open(...args) {
+        loadBinding();
+        const native = await binding.openAsyncHIDDevice(...args);
+        return new HIDAsync(native)
     }
 
     async close() {
@@ -181,20 +191,15 @@ function showdevices() {
     return binding.devices.apply(HID,arguments);
 }
 
-function showdevicesAsync() {
+function showdevicesAsync(...args) {
     loadBinding();
-    return binding.devicesAsync.apply(HID,arguments);
+    return binding.devicesAsync(...args);
 }
 
-async function openAsyncHIDDevice() {
-    loadBinding();
-    const native = await binding.openAsyncHIDDevice.apply(HID, arguments);
-    return new HIDAsync(native)
-}
 
 //Expose API
 exports.HID = HID;
+exports.HIDAsync = HIDAsync;
 exports.devices = showdevices;
 exports.devicesAsync = showdevicesAsync;
-exports.openAsyncHIDDevice = openAsyncHIDDevice;
 exports.setDriverType = setDriverType;

--- a/nodehid.js
+++ b/nodehid.js
@@ -35,9 +35,7 @@ function HID() {
     /* We also want to inherit from `binding.HID`, but unfortunately,
         it's not so easy for native Objects. For example, the
         following won't work since `new` keyword isn't used:
-
         `binding.HID.apply(this, arguments);`
-
         So... we do this craziness instead...
     */
     var thisPlusArgs = new Array(arguments.length + 1);
@@ -56,19 +54,15 @@ function HID() {
         this[i] = binding.HID.prototype[i].bind(this._raw);
 
     /* We are now done inheriting from `binding.HID` and EventEmitter.
-
         Now upon adding a new listener for "data" events, we start
         polling the HID device using `read(...)`
         See `resume()` for more details. */
+    this._paused = true;
     var self = this;
     self.on("newListener", function(eventName, listener) {
         if(eventName == "data")
             process.nextTick(self.resume.bind(self) );
     });
-    self.on("removeListener", function(eventName, listener) {
-        if(eventName == "data" && self.listenerCount("data") == 0)
-            process.nextTick(self.pause.bind(self) );
-    })
 }
 //Inherit prototype methods
 util.inherits(HID, EventEmitter);
@@ -82,23 +76,44 @@ HID.prototype.close = function close() {
 };
 //Pauses the reader, which stops "data" events from being emitted
 HID.prototype.pause = function pause() {
-    this._raw.readStop();
+    this._paused = true;
+};
+
+HID.prototype.read = function read(callback) {
+    if (this._closed) {
+    throw new Error('Unable to read from a closed HID device');
+  } else {
+    return this._raw.read(callback);
+  }
 };
 
 HID.prototype.resume = function resume() {
     var self = this;
-    if(self.listenerCount("data") > 0)
+    if(self._paused && self.listeners("data").length > 0)
     {
         //Start polling & reading loop
-        self._raw.readStart(function (err, data) {
-            if (err) {
+        self._paused = false;
+        self.read(function readFunc(err, data) {
+            if(err)
+            {
+                //Emit error and pause reading
+                self._paused = true;
                 if(!self._closing)
                     self.emit("error", err);
                 //else ignore any errors if I'm closing the device
-            } else {
+            }
+            else
+            {
+                //If there are no "data" listeners, we pause
+                if(self.listeners("data").length <= 0)
+                    self._paused = true;
+                //Keep reading if we aren't paused
+                if(!self._paused)
+                    self.read(readFunc);
+                //Now emit the event
                 self.emit("data", data);
             }
-        }, self)
+        });
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "hid-showdevices": "./src/show-devices.js"
   },
   "main": "./nodehid.js",
+  "types": "./nodehid.d.ts",
   "binary": {
     "napi_versions": [
       4

--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   "main": "./nodehid.js",
   "binary": {
     "napi_versions": [
-      3
+      4
     ]
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "license": "(MIT OR X11)",
   "dependencies": {
     "bindings": "^1.5.0",
-    "node-addon-api": "^3.0.2",
+    "node-addon-api": "^3.2.1",
     "prebuild-install": "^6.0.0"
   },
   "devDependencies": {

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -77,13 +77,13 @@ HID::HID(const Napi::CallbackInfo &info)
   {
     int32_t vendorId = info[0].As<Napi::Number>().Int32Value();
     int32_t productId = info[1].As<Napi::Number>().Int32Value();
-    wchar_t wserialstr[100]; // FIXME: is there a better way? TODO_ this is not thread safe!
-    wchar_t *wserialptr = NULL;
+    std::wstring wserialstr;
+    const wchar_t *wserialptr = nullptr;
     if (info.Length() > 2)
     {
       std::string serialstr = info[2].As<Napi::String>().Utf8Value();
-      mbstowcs(wserialstr, serialstr.c_str(), 100);
-      wserialptr = wserialstr;
+      wserialstr = utf8_decode(serialstr);
+      wserialptr = wserialstr.c_str();
     }
 
     {
@@ -356,13 +356,13 @@ Napi::Value HID::getDeviceInfo(const Napi::CallbackInfo &info)
   Napi::Object deviceInfo = Napi::Object::New(env);
 
   hid_get_manufacturer_string(_hidHandle, wstr, maxlen);
-  deviceInfo.Set("manufacturer", Napi::String::New(env, narrow(wstr)));
+  deviceInfo.Set("manufacturer", Napi::String::New(env, utf8_encode(wstr)));
 
   hid_get_product_string(_hidHandle, wstr, maxlen);
-  deviceInfo.Set("product", Napi::String::New(env, narrow(wstr)));
+  deviceInfo.Set("product", Napi::String::New(env, utf8_encode(wstr)));
 
   hid_get_serial_number_string(_hidHandle, wstr, maxlen);
-  deviceInfo.Set("serialNumber", Napi::String::New(env, narrow(wstr)));
+  deviceInfo.Set("serialNumber", Napi::String::New(env, utf8_encode(wstr)));
 
   return deviceInfo;
 }

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <vector>
 
+#include "devices.h"
 #include "util.h"
 #include "HID.h"
 
@@ -350,21 +351,14 @@ Napi::Value HID::getDeviceInfo(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
-  const int maxlen = 256;
-  wchar_t wstr[maxlen]; // FIXME: use new & delete
+  hid_device_info *dev = hid_get_device_info(_hidHandle);
+  if (!dev)
+  {
+    Napi::TypeError::New(env, "Unable to get device info").ThrowAsJavaScriptException();
+    return env.Null();
+  }
 
-  Napi::Object deviceInfo = Napi::Object::New(env);
-
-  hid_get_manufacturer_string(_hidHandle, wstr, maxlen);
-  deviceInfo.Set("manufacturer", Napi::String::New(env, utf8_encode(wstr)));
-
-  hid_get_product_string(_hidHandle, wstr, maxlen);
-  deviceInfo.Set("product", Napi::String::New(env, utf8_encode(wstr)));
-
-  hid_get_serial_number_string(_hidHandle, wstr, maxlen);
-  deviceInfo.Set("serialNumber", Napi::String::New(env, utf8_encode(wstr)));
-
-  return deviceInfo;
+  return generateDeviceInfo(env, dev);
 }
 
 Napi::Value HID::Initialize(Napi::Env &env)

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -157,7 +157,7 @@ public:
 
   void OnOK() override
   {
-    auto buffer = Napi::Buffer<unsigned char>::New(Env(), buf, len, deleteArray);
+    auto buffer = convertToNodeOwnerBuffer(Env(), buf, len);
     buf = nullptr; // It is now owned by the buffer
     Callback().Call({Env().Null(), buffer});
   }

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -37,7 +37,7 @@ HID::HID(const Napi::CallbackInfo &info)
     return;
   }
 
-  auto appCtx = getAppCtx();
+  auto appCtx = ApplicationContext::get();
   if (!appCtx)
   {
     Napi::TypeError::New(env, "hidapi not initialized").ThrowAsJavaScriptException();

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -128,11 +128,6 @@ void HID::closeHandle()
   }
 }
 
-void deleteArray(const Napi::Env &env, unsigned char *ptr)
-{
-  delete[] ptr;
-}
-
 class ReadWorker : public Napi::AsyncWorker
 {
 public:

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -26,8 +26,6 @@
 #include "util.h"
 #include "HID.h"
 
-#define READ_BUFF_MAXSIZE 2048
-
 HID::HID(const Napi::CallbackInfo &info)
     : Napi::ObjectWrap<HID>(info)
 {

--- a/src/HID.cc
+++ b/src/HID.cc
@@ -68,7 +68,7 @@ HID::HID(const Napi::CallbackInfo &info)
   {
     int32_t vendorId = info[0].As<Napi::Number>().Int32Value();
     int32_t productId = info[1].As<Napi::Number>().Int32Value();
-    wchar_t wserialstr[100]; // FIXME: is there a better way?
+    wchar_t wserialstr[100]; // FIXME: is there a better way? TODO_ this is not thread safe!
     wchar_t *wserialptr = NULL;
     if (info.Length() > 2)
     {

--- a/src/HID.h
+++ b/src/HID.h
@@ -1,0 +1,27 @@
+#include "util.h"
+
+class HID : public Napi::ObjectWrap<HID>
+{
+public:
+    static Napi::Value Initialize(Napi::Env &env);
+
+    void closeHandle();
+
+    HID(const Napi::CallbackInfo &info);
+    ~HID() { closeHandle(); }
+
+    hid_device *_hidHandle;
+
+private:
+    static Napi::Value devices(const Napi::CallbackInfo &info);
+
+    Napi::Value close(const Napi::CallbackInfo &info);
+    Napi::Value read(const Napi::CallbackInfo &info);
+    Napi::Value write(const Napi::CallbackInfo &info);
+    Napi::Value setNonBlocking(const Napi::CallbackInfo &info);
+    Napi::Value getFeatureReport(const Napi::CallbackInfo &info);
+    Napi::Value sendFeatureReport(const Napi::CallbackInfo &info);
+    Napi::Value readSync(const Napi::CallbackInfo &info);
+    Napi::Value readTimeout(const Napi::CallbackInfo &info);
+    Napi::Value getDeviceInfo(const Napi::CallbackInfo &info);
+};

--- a/src/HIDAsync.cc
+++ b/src/HIDAsync.cc
@@ -40,6 +40,13 @@ HIDAsync::HIDAsync(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
+  auto libRef = getLibRef();
+  if (!libRef)
+  {
+    Napi::TypeError::New(env, "hidapi not initialized").ThrowAsJavaScriptException();
+    return;
+  }
+
   if (!info.IsConstructCall())
   {
     Napi::TypeError::New(env, "HID function can only be used as a constructor").ThrowAsJavaScriptException();
@@ -71,7 +78,7 @@ HIDAsync::HIDAsync(const Napi::CallbackInfo &info)
       return;
     }
 
-    _hidHandle = std::make_shared<WrappedHidHandle>(hidHandle);
+    _hidHandle = std::make_shared<WrappedHidHandle>(libRef, hidHandle);
   }
   else
   {
@@ -94,7 +101,7 @@ HIDAsync::HIDAsync(const Napi::CallbackInfo &info)
       Napi::TypeError::New(env, os.str()).ThrowAsJavaScriptException();
       return;
     }
-    _hidHandle = std::make_shared<WrappedHidHandle>(hidHandle);
+    _hidHandle = std::make_shared<WrappedHidHandle>(libRef, hidHandle);
   }
 
   helper = std::make_shared<ReadHelper>(_hidHandle);

--- a/src/HIDAsync.cc
+++ b/src/HIDAsync.cc
@@ -123,7 +123,7 @@ public:
   {
     auto ptr = Napi::External<hid_device>::New(env, dev);
     dev = nullptr; // devs has already been freed
-    return constructor->Call({ptr});
+    return constructor->New({ptr});
   }
 
 private:
@@ -178,7 +178,7 @@ public:
   {
     auto ptr = Napi::External<hid_device>::New(env, dev);
     dev = nullptr; // devs has already been freed
-    return constructor->Call({ptr});
+    return constructor->New({ptr});
   }
 
 private:

--- a/src/HIDAsync.cc
+++ b/src/HIDAsync.cc
@@ -1,0 +1,951 @@
+// -*- C++ -*-
+
+// Copyright Hans Huebner and contributors. All rights reserved.
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use, copy,
+// modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+#include <thread>
+#include <atomic>
+#include <queue>
+#include <chrono>
+
+#include <stdlib.h>
+
+#include "util.h"
+
+#include <hidapi.h>
+
+#define READ_BUFF_MAXSIZE 2048
+
+class WrappedHidHandle
+{
+public:
+  WrappedHidHandle(hid_device *hidHandle) : hid(hidHandle) {}
+  ~WrappedHidHandle()
+  {
+    if (hid)
+    {
+      hid_close(hid);
+      hid = nullptr;
+    }
+
+    // TODO - discard the jobQueue in a safe manner
+  }
+
+  hid_device *hid;
+  std::mutex hidLock;
+
+  bool isRunning = false;
+  std::queue<Napi::AsyncWorker *> jobQueue;
+  std::mutex jobQueueMutex;
+
+  int count = 0;
+  std::chrono::nanoseconds time;
+
+  /**
+   * Push a job onto the queue.
+   * Note: This must only be run from the main thread
+   */
+  void QueueJob(const Napi::Env &, Napi::AsyncWorker *job)
+  {
+    std::unique_lock<std::mutex> lock(jobQueueMutex);
+    if (!isRunning)
+    {
+      isRunning = true;
+      job->Queue();
+    }
+    else
+    {
+      jobQueue.push(job);
+    }
+  }
+
+  /**
+   * The job has finished, start the next in the queue.
+   * Note: This must only be run from the main thread
+   */
+  void JobFinished(const Napi::Env &)
+  {
+    std::unique_lock<std::mutex> lock(jobQueueMutex);
+
+    if (jobQueue.size() == 0)
+    {
+      isRunning = false;
+    }
+    else
+    {
+      auto newJob = jobQueue.front();
+      jobQueue.pop();
+      newJob->Queue();
+    }
+  }
+};
+
+struct ReadCallbackProps
+{
+  unsigned char *buf;
+  int len;
+};
+
+inline void deleteArray(const Napi::Env &env, unsigned char *ptr)
+{
+  delete[] ptr;
+}
+
+static void ReadCallback(Napi::Env env, Napi::Function jsCallback, ReadCallbackProps *data)
+{
+  auto buffer = Napi::Buffer<unsigned char>::New(env, data->buf, data->len, deleteArray);
+  // buf is now owned by the buffer
+  delete data;
+
+  jsCallback.Call({env.Null(), buffer});
+};
+static void ReadErrorCallback(Napi::Env env, Napi::Function jsCallback, void *data)
+{
+  auto error = Napi::String::New(env, "could not read from HID device");
+
+  jsCallback.Call({error, env.Null()});
+};
+
+class ReadHelper
+{
+public:
+  ReadHelper(std::shared_ptr<WrappedHidHandle> hidHandle);
+  ~ReadHelper();
+
+  void start(Napi::Env env, Napi::Function callback);
+  void stop();
+
+  std::atomic<bool> run_read = {false};
+
+private:
+  std::shared_ptr<WrappedHidHandle> _hidHandle;
+  Napi::ThreadSafeFunction read_callback;
+  std::thread read_thread;
+};
+
+ReadHelper::ReadHelper(std::shared_ptr<WrappedHidHandle> hidHandle)
+{
+  _hidHandle = hidHandle;
+}
+ReadHelper::~ReadHelper()
+{
+  stop();
+}
+
+void ReadHelper::stop()
+{
+  run_read = false;
+
+  if (read_thread.joinable())
+  {
+    read_thread.join();
+  }
+}
+
+void ReadHelper::start(Napi::Env env, Napi::Function callback)
+{
+  // If the read is already running, then abort
+  if (run_read)
+    return;
+  run_read = true;
+
+  read_callback = Napi::ThreadSafeFunction::New(
+      env,
+      callback,        // JavaScript function called asynchronously
+      "HID:read",      // Name
+      0,               // Unlimited queue
+      1,               // Only one thread will use this initially
+      [=](Napi::Env) { // Finalizer used to clean threads up
+                       // Wait for end of the thread, if it wasnt the one to close up
+        if (read_thread.joinable())
+        {
+          read_thread.join();
+        }
+      });
+
+  read_thread = std::thread([=]()
+                            {
+                              int mswait = 50;
+                              int len = 0;
+                              unsigned char *buf = new unsigned char[READ_BUFF_MAXSIZE];
+
+                              run_read = true;
+                              while (run_read)
+                              {
+                                len = hid_read_timeout(_hidHandle->hid, buf, READ_BUFF_MAXSIZE, mswait);
+                                if (len < 0)
+                                {
+                                  // Emit and error and stop reading
+                                  read_callback.BlockingCall((void *)nullptr, ReadErrorCallback);
+                                  break;
+                                }
+                                else if (len > 0)
+                                {
+                                  auto data = new ReadCallbackProps;
+                                  data->buf = buf;
+                                  data->len = len;
+
+                                  read_callback.BlockingCall(data, ReadCallback);
+                                  // buf is now owned by ReadCallback
+                                  buf = new unsigned char[READ_BUFF_MAXSIZE];
+                                }
+                              }
+
+                              run_read = false;
+                              delete[] buf;
+
+                              // Cleanup the function
+                              read_callback.Release(); });
+}
+
+class HIDAsync : public Napi::ObjectWrap<HIDAsync>
+{
+public:
+  static void Initialize(Napi::Env &env, Napi::Object &exports);
+
+  void closeHandle();
+
+  HIDAsync(const Napi::CallbackInfo &info);
+  ~HIDAsync() { closeHandle(); }
+
+  std::shared_ptr<WrappedHidHandle> _hidHandle;
+
+private:
+  static Napi::Value devices(const Napi::CallbackInfo &info);
+
+  std::shared_ptr<ReadHelper> helper;
+
+  Napi::Value close(const Napi::CallbackInfo &info);
+  Napi::Value readStart(const Napi::CallbackInfo &info);
+  Napi::Value readStop(const Napi::CallbackInfo &info);
+  Napi::Value write(const Napi::CallbackInfo &info); // Asynced
+  Napi::Value setNonBlocking(const Napi::CallbackInfo &info);
+  Napi::Value getFeatureReport(const Napi::CallbackInfo &info);
+  Napi::Value getFeatureReportBuffer(const Napi::CallbackInfo &info);
+  Napi::Value sendFeatureReport(const Napi::CallbackInfo &info); // Asynced
+  Napi::Value readSync(const Napi::CallbackInfo &info);
+  Napi::Value readTimeout(const Napi::CallbackInfo &info);
+  Napi::Value getDeviceInfo(const Napi::CallbackInfo &info);
+};
+
+HIDAsync::HIDAsync(const Napi::CallbackInfo &info)
+    : Napi::ObjectWrap<HIDAsync>(info)
+{
+  Napi::Env env = info.Env();
+
+  if (!info.IsConstructCall())
+  {
+    Napi::TypeError::New(env, "HID function can only be used as a constructor").ThrowAsJavaScriptException();
+    return;
+  }
+
+  if (info.Length() < 1)
+  {
+    Napi::TypeError::New(env, "HID constructor requires at least one arguments").ThrowAsJavaScriptException();
+    return;
+  }
+
+  if (info.Length() == 1)
+  {
+    // open by path
+    if (!info[0].IsString())
+    {
+      Napi::TypeError::New(env, "Device path must be a string").ThrowAsJavaScriptException();
+      return;
+    }
+
+    std::string path = info[0].As<Napi::String>().Utf8Value();
+    auto hidHandle = hid_open_path(path.c_str());
+    if (!hidHandle)
+    {
+      std::ostringstream os;
+      os << "cannot open device with path " << path;
+      Napi::TypeError::New(env, os.str()).ThrowAsJavaScriptException();
+      return;
+    }
+
+    _hidHandle = std::make_shared<WrappedHidHandle>(hidHandle);
+  }
+  else
+  {
+    int32_t vendorId = info[0].As<Napi::Number>().Int32Value();
+    int32_t productId = info[1].As<Napi::Number>().Int32Value();
+    wchar_t wserialstr[100]; // FIXME: is there a better way?
+    wchar_t *wserialptr = NULL;
+    if (info.Length() > 2)
+    {
+      std::string serialstr = info[2].As<Napi::String>().Utf8Value();
+      mbstowcs(wserialstr, serialstr.c_str(), 100);
+      wserialptr = wserialstr;
+    }
+
+    auto hidHandle = hid_open(vendorId, productId, wserialptr);
+    if (!hidHandle)
+    {
+      std::ostringstream os;
+      os << "cannot open device with vendor id 0x" << std::hex << vendorId << " and product id 0x" << productId;
+      Napi::TypeError::New(env, os.str()).ThrowAsJavaScriptException();
+      return;
+    }
+    _hidHandle = std::make_shared<WrappedHidHandle>(hidHandle);
+  }
+
+  helper = std::make_shared<ReadHelper>(_hidHandle);
+}
+
+void HIDAsync::closeHandle()
+{
+  if (helper)
+  {
+    helper->stop();
+    helper = nullptr;
+  }
+
+  // hid_close is called by the destructor
+  _hidHandle = nullptr;
+}
+
+Napi::Value HIDAsync::readStart(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!helper)
+  {
+    Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  auto callback = info[0].As<Napi::Function>();
+  helper->start(env, callback);
+
+  return env.Null();
+}
+
+Napi::Value HIDAsync::readStop(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!helper)
+  {
+
+    // Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  helper->stop();
+
+  return env.Null();
+};
+
+Napi::Value HIDAsync::readSync(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!_hidHandle)
+  {
+    Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (helper != nullptr && helper->run_read)
+  {
+    Napi::TypeError::New(env, "Cannot use readSync while async read is running").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (info.Length() != 0)
+  {
+    Napi::TypeError::New(env, "readSync needs zero length parameter").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  unsigned char buff_read[READ_BUFF_MAXSIZE];
+  int returnedLength = hid_read(_hidHandle->hid, buff_read, sizeof buff_read);
+  if (returnedLength == -1)
+  {
+    Napi::TypeError::New(env, "could not read data from device").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  Napi::Array retval = Napi::Array::New(env, returnedLength);
+  for (int i = 0; i < returnedLength; i++)
+  {
+    retval.Set(i, Napi::Number::New(env, buff_read[i]));
+  }
+  return retval;
+}
+
+Napi::Value HIDAsync::readTimeout(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!_hidHandle)
+  {
+    Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (helper != nullptr && helper->run_read)
+  {
+    Napi::TypeError::New(env, "Cannot use readSync while async read is running").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (info.Length() != 1 || !info[0].IsNumber())
+  {
+    Napi::TypeError::New(env, "readTimeout needs time out parameter").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  const int timeout = info[0].As<Napi::Number>().Uint32Value();
+  unsigned char buff_read[READ_BUFF_MAXSIZE];
+  int returnedLength = hid_read_timeout(_hidHandle->hid, buff_read, sizeof buff_read, timeout);
+  if (returnedLength == -1)
+  {
+    Napi::TypeError::New(env, "could not read data from device").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  Napi::Array retval = Napi::Array::New(env, returnedLength);
+  for (int i = 0; i < returnedLength; i++)
+  {
+    retval.Set(i, Napi::Number::New(env, buff_read[i]));
+  }
+  return retval;
+}
+
+Napi::Value HIDAsync::getFeatureReport(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!_hidHandle)
+  {
+    Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (info.Length() != 2 || !info[0].IsNumber() || !info[1].IsNumber())
+  {
+    Napi::TypeError::New(env, "need report ID and length parameters in getFeatureReport").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  const uint8_t reportId = info[0].As<Napi::Number>().Uint32Value();
+  const int bufSize = info[1].As<Napi::Number>().Uint32Value();
+  if (bufSize == 0)
+  {
+    Napi::TypeError::New(env, "Length parameter cannot be zero in getFeatureReport").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  std::vector<unsigned char> buf(bufSize);
+  buf[0] = reportId;
+
+  int returnedLength;
+  {
+    std::unique_lock<std::mutex> lock(_hidHandle->hidLock);
+    returnedLength = hid_get_feature_report(_hidHandle->hid, buf.data(), bufSize);
+  }
+
+  if (returnedLength == -1)
+  {
+    Napi::TypeError::New(env, "could not get feature report from device").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  Napi::Array retval = Napi::Array::New(env, returnedLength);
+  for (int i = 0; i < returnedLength; i++)
+  {
+    retval.Set(i, Napi::Number::New(env, buf[i]));
+  }
+  return retval;
+}
+
+Napi::Value HIDAsync::getFeatureReportBuffer(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!_hidHandle)
+  {
+    Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (info.Length() != 2 || !info[0].IsNumber() || !info[1].IsNumber())
+  {
+    Napi::TypeError::New(env, "need report ID and length parameters in getFeatureReport").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  const uint8_t reportId = info[0].As<Napi::Number>().Uint32Value();
+  const int bufSize = info[1].As<Napi::Number>().Uint32Value();
+  if (bufSize == 0)
+  {
+    Napi::TypeError::New(env, "Length parameter cannot be zero in getFeatureReport").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  unsigned char *buf = new unsigned char[bufSize];
+  buf[0] = reportId;
+
+  int returnedLength;
+  {
+    std::unique_lock<std::mutex> lock(_hidHandle->hidLock);
+    returnedLength = hid_get_feature_report(_hidHandle->hid, buf, bufSize);
+  }
+
+  if (returnedLength == -1)
+  {
+    delete[] buf;
+    Napi::TypeError::New(env, "could not get feature report from device").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  // Pass ownership of `buf` to the Buffer
+  return Napi::Buffer<unsigned char>::New(env, buf, returnedLength, deleteArray);
+}
+
+class SendFeatureReportWorker : public Napi::AsyncWorker
+{
+public:
+  SendFeatureReportWorker(
+      Napi::Env &env,
+      std::shared_ptr<WrappedHidHandle> hid,
+      std::vector<unsigned char> srcBuffer)
+      : Napi::AsyncWorker(env),
+        _hid(hid),
+        deferred(Napi::Promise::Deferred::New(env)),
+        srcBuffer(srcBuffer) {}
+
+  // This code will be executed on the worker thread. Note: Napi types cannot be used
+  void Execute() override
+  {
+    if (_hid)
+    {
+      auto t1 = std::chrono::high_resolution_clock::now();
+      {
+        // std::unique_lock<std::mutex> lock(_hid->hidLock);
+        written = hid_send_feature_report(_hid->hid, srcBuffer.data(), srcBuffer.size());
+      }
+      auto t2 = std::chrono::high_resolution_clock::now();
+
+      _hid->count++;
+      if (_hid->count == 1)
+      {
+        _hid->time = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1);
+      }
+      else
+      {
+        _hid->time += std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1);
+      }
+
+      if (_hid->count == 10000)
+      {
+        std::cout << "Finished in " << std::chrono::duration_cast<std::chrono::milliseconds>(_hid->time).count() << "milliseconds" << std::endl;
+      }
+
+      if (written < 0)
+      {
+        SetError("could not send feature report to device");
+      }
+    }
+    else
+    {
+      SetError("No hid handle");
+    }
+  }
+
+  void OnOK() override
+  {
+    _hid->JobFinished(Env());
+    deferred.Resolve(Napi::Number::New(Env(), written));
+  }
+  void OnError(Napi::Error const &error) override
+  {
+    _hid->JobFinished(Env());
+    deferred.Reject(error.Value());
+  }
+
+  Napi::Promise GetPromise() const
+  {
+    return deferred.Promise();
+  }
+
+private:
+  std::shared_ptr<WrappedHidHandle> _hid;
+  int written = 0;
+  Napi::Promise::Deferred deferred;
+  std::vector<unsigned char> srcBuffer;
+};
+Napi::Value HIDAsync::sendFeatureReport(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!_hidHandle)
+  {
+    Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (info.Length() != 1)
+  {
+    Napi::TypeError::New(env, "need report (including id in first byte) only in sendFeatureReportAsync").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  std::vector<unsigned char> message;
+  std::string copyError = copyArrayOrBufferIntoVector(info[0], message);
+  if (copyError != "")
+  {
+    Napi::TypeError::New(env, copyError).ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  auto job = new SendFeatureReportWorker(env, _hidHandle, message);
+
+  _hidHandle->QueueJob(env, job);
+
+  return job->GetPromise();
+}
+
+Napi::Value HIDAsync::close(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  this->closeHandle();
+
+  return env.Null();
+}
+
+Napi::Value HIDAsync::setNonBlocking(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!_hidHandle)
+  {
+    Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (info.Length() != 1)
+  {
+    Napi::TypeError::New(env, "Expecting a 1 to enable, 0 to disable as the first argument.").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  int blockStatus = info[0].As<Napi::Number>().Int32Value();
+
+  int res;
+  {
+    std::unique_lock<std::mutex> lock(_hidHandle->hidLock);
+    res = hid_set_nonblocking(_hidHandle->hid, blockStatus);
+  }
+
+  if (res < 0)
+  {
+    Napi::TypeError::New(env, "Error setting non-blocking mode.").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  return env.Null();
+}
+
+class WriteWorker : public Napi::AsyncWorker
+{
+public:
+  WriteWorker(
+      Napi::Env &env,
+      std::shared_ptr<WrappedHidHandle> hid,
+      std::vector<unsigned char> srcBuffer)
+      : Napi::AsyncWorker(env),
+        _hid(hid),
+        deferred(Napi::Promise::Deferred::New(env)),
+        srcBuffer(srcBuffer) {}
+
+  // This code will be executed on the worker thread. Note: Napi types cannot be used
+  void Execute() override
+  {
+    if (_hid)
+    {
+      auto t1 = std::chrono::high_resolution_clock::now();
+      {
+        // std::unique_lock<std::mutex> lock(_hid->hidLock);
+        written = hid_write(_hid->hid, srcBuffer.data(), srcBuffer.size());
+      }
+
+      auto t2 = std::chrono::high_resolution_clock::now();
+
+      _hid->count++;
+      if (_hid->count == 1)
+      {
+        _hid->time = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1);
+      }
+      else
+      {
+        _hid->time += std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1);
+      }
+
+      if (_hid->count == 10000)
+      {
+        std::cout << "Finished in " << std::chrono::duration_cast<std::chrono::milliseconds>(_hid->time).count() << "milliseconds" << std::endl;
+      }
+
+      if (written < 0)
+      {
+        SetError("Cannot write to hid device");
+      }
+    }
+    else
+    {
+      SetError("No hid handle");
+    }
+  }
+
+  void OnOK() override
+  {
+    _hid->JobFinished(Env());
+    deferred.Resolve(Napi::Number::New(Env(), written));
+  }
+  void OnError(Napi::Error const &error) override
+  {
+    _hid->JobFinished(Env());
+    deferred.Reject(error.Value());
+  }
+
+  Napi::Promise GetPromise() const
+  {
+    return deferred.Promise();
+  }
+
+private:
+  std::shared_ptr<WrappedHidHandle> _hid;
+  int written = 0;
+  Napi::Promise::Deferred deferred;
+  std::vector<unsigned char> srcBuffer;
+};
+
+Napi::Value HIDAsync::write(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!_hidHandle)
+  {
+    Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (info.Length() != 1)
+  {
+    Napi::TypeError::New(env, "HID write requires one argument").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  std::vector<unsigned char> message;
+  std::string copyError = copyArrayOrBufferIntoVector(info[0], message);
+  if (copyError != "")
+  {
+    Napi::TypeError::New(env, copyError).ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  auto job = new WriteWorker(env, _hidHandle, std::move(message));
+
+  _hidHandle->QueueJob(env, job);
+
+  return job->GetPromise();
+}
+
+static std::string narrow(wchar_t *wide)
+{
+  std::wstring ws(wide);
+  std::ostringstream os;
+  for (size_t i = 0; i < ws.size(); i++)
+  {
+    os << os.narrow(ws[i], '?');
+  }
+  return os.str();
+}
+
+Napi::Value HIDAsync::getDeviceInfo(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  if (!_hidHandle)
+  {
+    Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  const int maxlen = 256;
+  wchar_t wstr[maxlen]; // FIXME: use new & delete
+
+  Napi::Object deviceInfo = Napi::Object::New(env);
+
+  {
+    std::unique_lock<std::mutex> lock(_hidHandle->hidLock);
+
+    hid_get_manufacturer_string(_hidHandle->hid, wstr, maxlen);
+    deviceInfo.Set("manufacturer", Napi::String::New(env, narrow(wstr)));
+
+    hid_get_product_string(_hidHandle->hid, wstr, maxlen);
+    deviceInfo.Set("product", Napi::String::New(env, narrow(wstr)));
+
+    hid_get_serial_number_string(_hidHandle->hid, wstr, maxlen);
+    deviceInfo.Set("serialNumber", Napi::String::New(env, narrow(wstr)));
+  }
+
+  return deviceInfo;
+}
+
+Napi::Value HIDAsync::devices(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  int vendorId = 0;
+  int productId = 0;
+
+  switch (info.Length())
+  {
+  case 0:
+    break;
+  case 2:
+    vendorId = info[0].As<Napi::Number>().Int32Value();
+    productId = info[1].As<Napi::Number>().Int32Value();
+    break;
+  default:
+    Napi::TypeError::New(env, "unexpected number of arguments to HID.devices() call, expecting either no arguments or vendor and product ID").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  hid_device_info *devs = hid_enumerate(vendorId, productId);
+  Napi::Array retval = Napi::Array::New(env);
+  int count = 0;
+  for (hid_device_info *dev = devs; dev; dev = dev->next)
+  {
+    Napi::Object deviceInfo = Napi::Object::New(env);
+    deviceInfo.Set("vendorId", Napi::Number::New(env, dev->vendor_id));
+    deviceInfo.Set("productId", Napi::Number::New(env, dev->product_id));
+    if (dev->path)
+    {
+      deviceInfo.Set("path", Napi::String::New(env, dev->path));
+    }
+    if (dev->serial_number)
+    {
+      deviceInfo.Set("serialNumber", Napi::String::New(env, narrow(dev->serial_number)));
+    }
+    if (dev->manufacturer_string)
+    {
+      deviceInfo.Set("manufacturer", Napi::String::New(env, narrow(dev->manufacturer_string)));
+    }
+    if (dev->product_string)
+    {
+      deviceInfo.Set("product", Napi::String::New(env, narrow(dev->product_string)));
+    }
+    deviceInfo.Set("release", Napi::Number::New(env, dev->release_number));
+    deviceInfo.Set("interface", Napi::Number::New(env, dev->interface_number));
+    if (dev->usage_page)
+    {
+      deviceInfo.Set("usagePage", Napi::Number::New(env, dev->usage_page));
+    }
+    if (dev->usage)
+    {
+      deviceInfo.Set("usage", Napi::Number::New(env, dev->usage));
+    }
+    retval.Set(count++, deviceInfo);
+  }
+  hid_free_enumeration(devs);
+  return retval;
+}
+
+// // Ensure hid_init/hid_exit is coordinated across all threads
+// std::mutex initLock;
+// uint16_t activeThreads = 0;
+
+// static void
+// deinitialize(void *)
+// {
+//   // Make sure we run init on only one thread
+//   std::unique_lock<std::mutex> lock(initLock);
+
+//   activeThreads--;
+
+//   if (activeThreads == 0)
+//   {
+//     // TODO: libusb might be grumpy about this. Is it being called before the hid devices have been disposed?
+//     if (hid_exit())
+//     {
+//       // thread is exiting, can't log? TODO
+//       // Napi::TypeError::New(env, "cannot uninitialize hidapi (hid_exit failed)").ThrowAsJavaScriptException();
+//       return;
+//     }
+//   }
+// }
+void HIDAsync::Initialize(Napi::Env &env, Napi::Object &exports)
+{
+  // std::shared_ptr<void> ref;
+  // {
+  //   // Make sure we run init on only one thread
+  //   std::unique_lock<std::mutex> lock(initLock);
+
+  //   if (activeThreads == 0)
+  //   {
+  //     // Not initialised, so lets do that
+  //     if (hid_init())
+  //     {
+  //       Napi::TypeError::New(env, "cannot initialize hidapi (hid_init failed)").ThrowAsJavaScriptException();
+  //       return;
+  //     }
+  //   }
+
+  //   activeThreads++;
+  // }
+
+  // napi_add_env_cleanup_hook(env, deinitialize, nullptr);
+
+  Napi::Function ctor = DefineClass(env, "HID", {
+                                                    InstanceMethod("close", &HIDAsync::close),
+                                                    InstanceMethod("readStart", &HIDAsync::readStart),
+                                                    InstanceMethod("readStop", &HIDAsync::readStop),
+                                                    InstanceMethod("write", &HIDAsync::write, napi_enumerable),
+                                                    InstanceMethod("getFeatureReport", &HIDAsync::getFeatureReport, napi_enumerable),
+                                                    InstanceMethod("getFeatureReportBuffer", &HIDAsync::getFeatureReportBuffer, napi_enumerable),
+                                                    InstanceMethod("sendFeatureReport", &HIDAsync::sendFeatureReport, napi_enumerable),
+                                                    InstanceMethod("setNonBlocking", &HIDAsync::setNonBlocking, napi_enumerable),
+                                                    InstanceMethod("readSync", &HIDAsync::readSync, napi_enumerable),
+                                                    InstanceMethod("readTimeout", &HIDAsync::readTimeout, napi_enumerable),
+                                                    InstanceMethod("getDeviceInfo", &HIDAsync::getDeviceInfo, napi_enumerable),
+                                                });
+
+  exports.Set("HID", ctor);
+  exports.Set("devices", Napi::Function::New(env, &HIDAsync::devices));
+}
+
+// Napi::Object Init(Napi::Env env, Napi::Object exports)
+// {
+//   HIDAsync::Initialize(env, exports);
+
+//   return exports;
+// }
+
+// NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/src/HIDAsync.cc
+++ b/src/HIDAsync.cc
@@ -154,12 +154,12 @@ public:
   {
     std::unique_lock<std::mutex> lock(context->appCtx->enumerateLock);
 
-    wchar_t wserialstr[100]; // FIXME: is there a better way?
-    wchar_t *wserialptr = NULL;
+    std::wstring wserialstr;
+    const wchar_t *wserialptr = nullptr;
     if (serial != "")
     {
-      mbstowcs(wserialstr, serial.c_str(), 100); // TODO: this is not thread safe!
-      wserialptr = wserialstr;
+      wserialstr = utf8_decode(serial);
+      wserialptr = wserialstr.c_str();
     }
 
     dev = hid_open(vendorId, productId, wserialptr);
@@ -670,17 +670,17 @@ public:
 
       if (hid_get_manufacturer_string(context->hid, wstr, maxlen) == 0)
       {
-        resManufacturer = narrow(wstr);
+        resManufacturer = utf8_encode(wstr);
       }
 
       if (hid_get_product_string(context->hid, wstr, maxlen) == 0)
       {
-        resProduct = narrow(wstr);
+        resProduct = utf8_encode(wstr);
       }
 
       if (hid_get_serial_number_string(context->hid, wstr, maxlen) == 0)
       {
-        resSerialNumber = narrow(wstr);
+        resSerialNumber = utf8_encode(wstr);
       }
     }
     else

--- a/src/HIDAsync.cc
+++ b/src/HIDAsync.cc
@@ -64,7 +64,7 @@ public:
     if (context->hid)
     {
       hid_close(context->hid);
-      context->hid = nullptr; // TODO - we need to null check this in other workers
+      context->hid = nullptr;
     }
   }
 
@@ -203,8 +203,6 @@ Napi::Value HIDAsync::Create(const Napi::CallbackInfo &info)
   }
   ContextState *context = (ContextState *)data;
 
-  // TODO
-
   if (info.Length() == 1)
   {
     // open by path
@@ -301,7 +299,7 @@ public:
     if (context->hid)
     {
       buffer = new unsigned char[READ_BUFF_MAXSIZE];
-      // TODO: Is this necessary? Docs say that hid_read_timeout with -1 is 'blocking', but dont clarify what that means when set to nonblocking mode
+      // This is wordy, but necessary to get the correct non-blocking behaviour
       if (_timeout == -1)
       {
         returnedLength = hid_read(context->hid, buffer, READ_BUFF_MAXSIZE);

--- a/src/HIDAsync.cc
+++ b/src/HIDAsync.cc
@@ -141,7 +141,7 @@ Napi::Value HIDAsync::readStart(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
-  if (!helper)
+  if (!helper || _hidHandle->is_closed)
   {
     Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
     return env.Null();
@@ -232,7 +232,7 @@ Napi::Value HIDAsync::read(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
-  if (!_hidHandle)
+  if (!_hidHandle || _hidHandle->is_closed)
   {
     Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
     return env.Null();
@@ -318,7 +318,7 @@ Napi::Value HIDAsync::getFeatureReport(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
-  if (!_hidHandle)
+  if (!_hidHandle || _hidHandle->is_closed)
   {
     Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
     return env.Null();
@@ -382,7 +382,7 @@ Napi::Value HIDAsync::sendFeatureReport(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
-  if (!_hidHandle)
+  if (!_hidHandle || _hidHandle->is_closed)
   {
     Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
     return env.Null();
@@ -409,7 +409,16 @@ Napi::Value HIDAsync::close(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
+  if (!_hidHandle || _hidHandle->is_closed)
+  {
+    Napi::TypeError::New(env, "device is already closed").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
   // TODO - option to flush or purge queued operations
+
+  // Mark it as closed, to stop new jobs being pushed to the queue
+  _hidHandle->is_closed = true;
 
   auto result = (new CloseWorker(env, _hidHandle))->QueueAndRun();
 
@@ -458,7 +467,7 @@ Napi::Value HIDAsync::setNonBlocking(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
-  if (!_hidHandle)
+  if (!_hidHandle || _hidHandle->is_closed)
   {
     Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
     return env.Null();
@@ -516,7 +525,7 @@ Napi::Value HIDAsync::write(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
-  if (!_hidHandle)
+  if (!_hidHandle || _hidHandle->is_closed)
   {
     Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
     return env.Null();
@@ -596,7 +605,7 @@ Napi::Value HIDAsync::getDeviceInfo(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
 
-  if (!_hidHandle)
+  if (!_hidHandle || _hidHandle->is_closed)
   {
     Napi::TypeError::New(env, "device has been closed").ThrowAsJavaScriptException();
     return env.Null();

--- a/src/HIDAsync.cc
+++ b/src/HIDAsync.cc
@@ -20,16 +20,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-#include <iostream>
-#include <iomanip>
 #include <sstream>
 #include <vector>
-#include <thread>
-#include <atomic>
 #include <queue>
-#include <chrono>
-
-#include <stdlib.h>
 
 #include "util.h"
 #include "HIDAsync.h"
@@ -579,17 +572,6 @@ Napi::Value HIDAsync::write(const Napi::CallbackInfo &info)
   return job->GetPromise();
 }
 
-static std::string narrow(wchar_t *wide)
-{
-  std::wstring ws(wide);
-  std::ostringstream os;
-  for (size_t i = 0; i < ws.size(); i++)
-  {
-    os << os.narrow(ws[i], '?');
-  }
-  return os.str();
-}
-
 class GetDeviceInfoWorker : public MyAsyncWorker
 {
 public:
@@ -658,66 +640,6 @@ Napi::Value HIDAsync::getDeviceInfo(const Napi::CallbackInfo &info)
   _hidHandle->QueueJob(env, job);
 
   return job->GetPromise();
-}
-
-Napi::Value HIDAsync::devices(const Napi::CallbackInfo &info)
-{
-  Napi::Env env = info.Env();
-
-  int vendorId = 0;
-  int productId = 0;
-
-  switch (info.Length())
-  {
-  case 0:
-    break;
-  case 2:
-    vendorId = info[0].As<Napi::Number>().Int32Value();
-    productId = info[1].As<Napi::Number>().Int32Value();
-    break;
-  default:
-    Napi::TypeError::New(env, "unexpected number of arguments to HID.devices() call, expecting either no arguments or vendor and product ID").ThrowAsJavaScriptException();
-    return env.Null();
-  }
-
-  hid_device_info *devs = hid_enumerate(vendorId, productId);
-  Napi::Array retval = Napi::Array::New(env);
-  int count = 0;
-  for (hid_device_info *dev = devs; dev; dev = dev->next)
-  {
-    Napi::Object deviceInfo = Napi::Object::New(env);
-    deviceInfo.Set("vendorId", Napi::Number::New(env, dev->vendor_id));
-    deviceInfo.Set("productId", Napi::Number::New(env, dev->product_id));
-    if (dev->path)
-    {
-      deviceInfo.Set("path", Napi::String::New(env, dev->path));
-    }
-    if (dev->serial_number)
-    {
-      deviceInfo.Set("serialNumber", Napi::String::New(env, narrow(dev->serial_number)));
-    }
-    if (dev->manufacturer_string)
-    {
-      deviceInfo.Set("manufacturer", Napi::String::New(env, narrow(dev->manufacturer_string)));
-    }
-    if (dev->product_string)
-    {
-      deviceInfo.Set("product", Napi::String::New(env, narrow(dev->product_string)));
-    }
-    deviceInfo.Set("release", Napi::Number::New(env, dev->release_number));
-    deviceInfo.Set("interface", Napi::Number::New(env, dev->interface_number));
-    if (dev->usage_page)
-    {
-      deviceInfo.Set("usagePage", Napi::Number::New(env, dev->usage_page));
-    }
-    if (dev->usage)
-    {
-      deviceInfo.Set("usage", Napi::Number::New(env, dev->usage));
-    }
-    retval.Set(count++, deviceInfo);
-  }
-  hid_free_enumeration(devs);
-  return retval;
 }
 
 Napi::Value HIDAsync::Initialize(Napi::Env &env)

--- a/src/HIDAsync.h
+++ b/src/HIDAsync.h
@@ -14,8 +14,6 @@ public:
     std::shared_ptr<WrappedHidHandle> _hidHandle;
 
 private:
-    static Napi::Value devices(const Napi::CallbackInfo &info);
-
     std::shared_ptr<ReadHelper> helper;
 
     Napi::Value close(const Napi::CallbackInfo &info);

--- a/src/HIDAsync.h
+++ b/src/HIDAsync.h
@@ -15,6 +15,8 @@ private:
 
     void closeHandle();
 
+    static Napi::Value Create(const Napi::CallbackInfo &info);
+
     Napi::Value close(const Napi::CallbackInfo &info);
     Napi::Value readStart(const Napi::CallbackInfo &info);
     Napi::Value readStop(const Napi::CallbackInfo &info);

--- a/src/HIDAsync.h
+++ b/src/HIDAsync.h
@@ -4,7 +4,9 @@
 class HIDAsync : public Napi::ObjectWrap<HIDAsync>
 {
 public:
-    static Napi::Value Initialize(Napi::Env &env);
+    static Napi::Function Initialize(Napi::Env &env);
+
+    static Napi::Value Create(const Napi::CallbackInfo &info);
 
     HIDAsync(const Napi::CallbackInfo &info);
     ~HIDAsync() { closeHandle(); }
@@ -14,8 +16,6 @@ private:
     std::shared_ptr<WrappedHidHandle> _hidHandle;
 
     void closeHandle();
-
-    static Napi::Value Create(const Napi::CallbackInfo &info);
 
     Napi::Value close(const Napi::CallbackInfo &info);
     Napi::Value readStart(const Napi::CallbackInfo &info);

--- a/src/HIDAsync.h
+++ b/src/HIDAsync.h
@@ -13,7 +13,7 @@ public:
 
 private:
     std::shared_ptr<ReadHelper> helper;
-    std::shared_ptr<WrappedHidHandle> _hidHandle;
+    std::shared_ptr<DeviceContext> _hidHandle;
 
     void closeHandle();
 

--- a/src/HIDAsync.h
+++ b/src/HIDAsync.h
@@ -1,0 +1,30 @@
+#include "util.h"
+#include "read.h"
+
+class HIDAsync : public Napi::ObjectWrap<HIDAsync>
+{
+public:
+    static Napi::Value Initialize(Napi::Env &env);
+
+    void closeHandle();
+
+    HIDAsync(const Napi::CallbackInfo &info);
+    ~HIDAsync() { closeHandle(); }
+
+    std::shared_ptr<WrappedHidHandle> _hidHandle;
+
+private:
+    static Napi::Value devices(const Napi::CallbackInfo &info);
+
+    std::shared_ptr<ReadHelper> helper;
+
+    Napi::Value close(const Napi::CallbackInfo &info);
+    Napi::Value readStart(const Napi::CallbackInfo &info);         // OK
+    Napi::Value readStop(const Napi::CallbackInfo &info);          // OK
+    Napi::Value write(const Napi::CallbackInfo &info);             // Asynced
+    Napi::Value setNonBlocking(const Napi::CallbackInfo &info);    // Asynced
+    Napi::Value getFeatureReport(const Napi::CallbackInfo &info);  // Asynced
+    Napi::Value sendFeatureReport(const Napi::CallbackInfo &info); // Asynced
+    Napi::Value read(const Napi::CallbackInfo &info);              // Asynced
+    Napi::Value getDeviceInfo(const Napi::CallbackInfo &info);     // Asynced
+};

--- a/src/HIDAsync.h
+++ b/src/HIDAsync.h
@@ -6,23 +6,22 @@ class HIDAsync : public Napi::ObjectWrap<HIDAsync>
 public:
     static Napi::Value Initialize(Napi::Env &env);
 
-    void closeHandle();
-
     HIDAsync(const Napi::CallbackInfo &info);
     ~HIDAsync() { closeHandle(); }
 
-    std::shared_ptr<WrappedHidHandle> _hidHandle;
-
 private:
     std::shared_ptr<ReadHelper> helper;
+    std::shared_ptr<WrappedHidHandle> _hidHandle;
+
+    void closeHandle();
 
     Napi::Value close(const Napi::CallbackInfo &info);
-    Napi::Value readStart(const Napi::CallbackInfo &info);         // OK
-    Napi::Value readStop(const Napi::CallbackInfo &info);          // OK
-    Napi::Value write(const Napi::CallbackInfo &info);             // Asynced
-    Napi::Value setNonBlocking(const Napi::CallbackInfo &info);    // Asynced
-    Napi::Value getFeatureReport(const Napi::CallbackInfo &info);  // Asynced
-    Napi::Value sendFeatureReport(const Napi::CallbackInfo &info); // Asynced
-    Napi::Value read(const Napi::CallbackInfo &info);              // Asynced
-    Napi::Value getDeviceInfo(const Napi::CallbackInfo &info);     // Asynced
+    Napi::Value readStart(const Napi::CallbackInfo &info);
+    Napi::Value readStop(const Napi::CallbackInfo &info);
+    Napi::Value write(const Napi::CallbackInfo &info);
+    Napi::Value setNonBlocking(const Napi::CallbackInfo &info);
+    Napi::Value getFeatureReport(const Napi::CallbackInfo &info);
+    Napi::Value sendFeatureReport(const Napi::CallbackInfo &info);
+    Napi::Value read(const Napi::CallbackInfo &info);
+    Napi::Value getDeviceInfo(const Napi::CallbackInfo &info);
 };

--- a/src/buzzers.js
+++ b/src/buzzers.js
@@ -30,7 +30,7 @@ function BuzzerController(index)
 
     // Initialize buzzers
     this.hid.write([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
-    this.hid.read(this.buzzerData.bind(this));
+    this.hid.on('data', this.buzzerData.bind(this));
 }
 
 util.inherits(BuzzerController, events.EventEmitter);
@@ -48,14 +48,13 @@ BuzzerController.prototype.handleBuzzer = function (buzzerNumber, bits)
     }
 }
 
-BuzzerController.prototype.buzzerData = function (error, data) {
-    console.log('error', error, 'data', data);
+BuzzerController.prototype.buzzerData = function ( data) {
+    console.log('data', data);
     var bits = (data[4] << 16) | (data[3] << 8) | data[2];
     for (var i = 0; i < 4; i++) {
         this.handleBuzzer(i, bits);
     }
     this.oldBits = bits;
-    this.hid.read(this.buzzerData.bind(this));
 }
 
 BuzzerController.prototype.led = function(buzzer, state) {

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -30,15 +30,15 @@ Napi::Value generateDevicesResultAndFree(const Napi::Env &env, hid_device_info *
         }
         if (dev->serial_number)
         {
-            deviceInfo.Set("serialNumber", Napi::String::New(env, utf8_encode(dev->serial_number)));
+            deviceInfo.Set("serialNumber", Napi::String::New(env, narrow(dev->serial_number)));
         }
         if (dev->manufacturer_string)
         {
-            deviceInfo.Set("manufacturer", Napi::String::New(env, utf8_encode(dev->manufacturer_string)));
+            deviceInfo.Set("manufacturer", Napi::String::New(env, narrow(dev->manufacturer_string)));
         }
         if (dev->product_string)
         {
-            deviceInfo.Set("product", Napi::String::New(env, utf8_encode(dev->product_string)));
+            deviceInfo.Set("product", Napi::String::New(env, narrow(dev->product_string)));
         }
         deviceInfo.Set("release", Napi::Number::New(env, dev->release_number));
         deviceInfo.Set("interface", Napi::Number::New(env, dev->interface_number));

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -30,15 +30,15 @@ Napi::Value generateDevicesResultAndFree(const Napi::Env &env, hid_device_info *
         }
         if (dev->serial_number)
         {
-            deviceInfo.Set("serialNumber", Napi::String::New(env, narrow(dev->serial_number)));
+            deviceInfo.Set("serialNumber", Napi::String::New(env, utf8_encode(dev->serial_number)));
         }
         if (dev->manufacturer_string)
         {
-            deviceInfo.Set("manufacturer", Napi::String::New(env, narrow(dev->manufacturer_string)));
+            deviceInfo.Set("manufacturer", Napi::String::New(env, utf8_encode(dev->manufacturer_string)));
         }
         if (dev->product_string)
         {
-            deviceInfo.Set("product", Napi::String::New(env, narrow(dev->product_string)));
+            deviceInfo.Set("product", Napi::String::New(env, utf8_encode(dev->product_string)));
         }
         deviceInfo.Set("release", Napi::Number::New(env, dev->release_number));
         deviceInfo.Set("interface", Napi::Number::New(env, dev->interface_number));

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -21,39 +21,44 @@ Napi::Value generateDevicesResultAndFree(const Napi::Env &env, hid_device_info *
     int count = 0;
     for (hid_device_info *dev = devs; dev; dev = dev->next)
     {
-        Napi::Object deviceInfo = Napi::Object::New(env);
-        deviceInfo.Set("vendorId", Napi::Number::New(env, dev->vendor_id));
-        deviceInfo.Set("productId", Napi::Number::New(env, dev->product_id));
-        if (dev->path)
-        {
-            deviceInfo.Set("path", Napi::String::New(env, dev->path));
-        }
-        if (dev->serial_number)
-        {
-            deviceInfo.Set("serialNumber", Napi::String::New(env, utf8_encode(dev->serial_number)));
-        }
-        if (dev->manufacturer_string)
-        {
-            deviceInfo.Set("manufacturer", Napi::String::New(env, utf8_encode(dev->manufacturer_string)));
-        }
-        if (dev->product_string)
-        {
-            deviceInfo.Set("product", Napi::String::New(env, utf8_encode(dev->product_string)));
-        }
-        deviceInfo.Set("release", Napi::Number::New(env, dev->release_number));
-        deviceInfo.Set("interface", Napi::Number::New(env, dev->interface_number));
-        if (dev->usage_page)
-        {
-            deviceInfo.Set("usagePage", Napi::Number::New(env, dev->usage_page));
-        }
-        if (dev->usage)
-        {
-            deviceInfo.Set("usage", Napi::Number::New(env, dev->usage));
-        }
-        retval.Set(count++, deviceInfo);
+        retval.Set(count++, generateDeviceInfo(env, dev));
     }
     hid_free_enumeration(devs);
     return retval;
+}
+
+Napi::Value generateDeviceInfo(const Napi::Env &env, hid_device_info *dev)
+{
+    Napi::Object deviceInfo = Napi::Object::New(env);
+    deviceInfo.Set("vendorId", Napi::Number::New(env, dev->vendor_id));
+    deviceInfo.Set("productId", Napi::Number::New(env, dev->product_id));
+    if (dev->path)
+    {
+        deviceInfo.Set("path", Napi::String::New(env, dev->path));
+    }
+    if (dev->serial_number)
+    {
+        deviceInfo.Set("serialNumber", Napi::String::New(env, utf8_encode(dev->serial_number)));
+    }
+    if (dev->manufacturer_string)
+    {
+        deviceInfo.Set("manufacturer", Napi::String::New(env, utf8_encode(dev->manufacturer_string)));
+    }
+    if (dev->product_string)
+    {
+        deviceInfo.Set("product", Napi::String::New(env, utf8_encode(dev->product_string)));
+    }
+    deviceInfo.Set("release", Napi::Number::New(env, dev->release_number));
+    deviceInfo.Set("interface", Napi::Number::New(env, dev->interface_number));
+    if (dev->usage_page)
+    {
+        deviceInfo.Set("usagePage", Napi::Number::New(env, dev->usage_page));
+    }
+    if (dev->usage)
+    {
+        deviceInfo.Set("usage", Napi::Number::New(env, dev->usage));
+    }
+    return deviceInfo;
 }
 
 Napi::Value devices(const Napi::CallbackInfo &info)

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -68,8 +68,8 @@ Napi::Value devices(const Napi::CallbackInfo &info)
         return env.Null();
     }
 
-    auto libRef = getAppCtx();
-    if (!libRef)
+    auto appCtx = getAppCtx();
+    if (!appCtx)
     {
         Napi::TypeError::New(env, "hidapi not initialized").ThrowAsJavaScriptException();
         return env.Null();
@@ -77,7 +77,7 @@ Napi::Value devices(const Napi::CallbackInfo &info)
 
     hid_device_info *devs;
     {
-        std::unique_lock<std::mutex> lock(libRef->enumerateLock);
+        std::unique_lock<std::mutex> lock(appCtx->enumerateLock);
         devs = hid_enumerate(vendorId, productId);
     }
     return generateDevicesResultAndFree(env, devs);
@@ -118,7 +118,7 @@ public:
         }
         else
         {
-            return env.Null();
+            return Napi::Array::New(env, 0);
         }
     }
 

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -30,15 +30,15 @@ Napi::Value generateDevicesResultAndFree(const Napi::Env &env, hid_device_info *
         }
         if (dev->serial_number)
         {
-            deviceInfo.Set("serialNumber", Napi::String::New(env, narrow(dev->serial_number)));
+            deviceInfo.Set("serialNumber", Napi::String::New(env, utf8_encode(dev->serial_number)));
         }
         if (dev->manufacturer_string)
         {
-            deviceInfo.Set("manufacturer", Napi::String::New(env, narrow(dev->manufacturer_string)));
+            deviceInfo.Set("manufacturer", Napi::String::New(env, utf8_encode(dev->manufacturer_string)));
         }
         if (dev->product_string)
         {
-            deviceInfo.Set("product", Napi::String::New(env, narrow(dev->product_string)));
+            deviceInfo.Set("product", Napi::String::New(env, utf8_encode(dev->product_string)));
         }
         deviceInfo.Set("release", Napi::Number::New(env, dev->release_number));
         deviceInfo.Set("interface", Napi::Number::New(env, dev->interface_number));
@@ -145,7 +145,7 @@ Napi::Value devicesAsync(const Napi::CallbackInfo &info)
     if (!parseDevicesParameters(info, &vendorId, &productId))
     {
 
-        Napi::TypeError::New(env, "unexpected number of arguments to HID.devices() call, expecting either no arguments or vendor and product ID").ThrowAsJavaScriptException();
+        Napi::TypeError::New(env, "unexpected number of arguments to HID.devicesAsync() call, expecting either no arguments or vendor and product ID").ThrowAsJavaScriptException();
         return env.Null();
     }
 

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -1,0 +1,61 @@
+#include "devices.h"
+
+Napi::Value devices(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+
+    int vendorId = 0;
+    int productId = 0;
+
+    switch (info.Length())
+    {
+    case 0:
+        break;
+    case 2:
+        vendorId = info[0].As<Napi::Number>().Int32Value();
+        productId = info[1].As<Napi::Number>().Int32Value();
+        break;
+    default:
+        Napi::TypeError::New(env, "unexpected number of arguments to HID.devices() call, expecting either no arguments or vendor and product ID").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    hid_device_info *devs = hid_enumerate(vendorId, productId);
+    Napi::Array retval = Napi::Array::New(env);
+    int count = 0;
+    for (hid_device_info *dev = devs; dev; dev = dev->next)
+    {
+        Napi::Object deviceInfo = Napi::Object::New(env);
+        deviceInfo.Set("vendorId", Napi::Number::New(env, dev->vendor_id));
+        deviceInfo.Set("productId", Napi::Number::New(env, dev->product_id));
+        if (dev->path)
+        {
+            deviceInfo.Set("path", Napi::String::New(env, dev->path));
+        }
+        if (dev->serial_number)
+        {
+            deviceInfo.Set("serialNumber", Napi::String::New(env, narrow(dev->serial_number)));
+        }
+        if (dev->manufacturer_string)
+        {
+            deviceInfo.Set("manufacturer", Napi::String::New(env, narrow(dev->manufacturer_string)));
+        }
+        if (dev->product_string)
+        {
+            deviceInfo.Set("product", Napi::String::New(env, narrow(dev->product_string)));
+        }
+        deviceInfo.Set("release", Napi::Number::New(env, dev->release_number));
+        deviceInfo.Set("interface", Napi::Number::New(env, dev->interface_number));
+        if (dev->usage_page)
+        {
+            deviceInfo.Set("usagePage", Napi::Number::New(env, dev->usage_page));
+        }
+        if (dev->usage)
+        {
+            deviceInfo.Set("usage", Napi::Number::New(env, dev->usage));
+        }
+        retval.Set(count++, deviceInfo);
+    }
+    hid_free_enumeration(devs);
+    return retval;
+}

--- a/src/devices.h
+++ b/src/devices.h
@@ -1,5 +1,7 @@
 #include "util.h"
 
+Napi::Value generateDeviceInfo(const Napi::Env &env, hid_device_info *dev);
+
 Napi::Value devices(const Napi::CallbackInfo &info);
 
 Napi::Value devicesAsync(const Napi::CallbackInfo &info);

--- a/src/devices.h
+++ b/src/devices.h
@@ -1,0 +1,3 @@
+#include "util.h"
+
+Napi::Value devices(const Napi::CallbackInfo &info);

--- a/src/devices.h
+++ b/src/devices.h
@@ -1,3 +1,5 @@
 #include "util.h"
 
 Napi::Value devices(const Napi::CallbackInfo &info);
+
+Napi::Value devicesAsync(const Napi::CallbackInfo &info);

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -21,10 +21,10 @@ deinitialize(void *ptr)
 Napi::Object
 Init(Napi::Env env, Napi::Object exports)
 {
-    std::shared_ptr<void> ref = getLibRef(env);
+    std::shared_ptr<void> ref = getLibRef();
     if (ref == nullptr)
     {
-        // getLibRef threw an error
+        Napi::TypeError::New(env, "cannot initialize hidapi (hid_init failed)").ThrowAsJavaScriptException();
         return exports;
     }
 

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -1,0 +1,41 @@
+#include <mutex>
+
+#include "util.h"
+
+#include "HID.h"
+#include "HIDAsync.h"
+
+struct libRef
+{
+    // Wrap a shared_ptr in a struct we can use a normal pointer
+    std::shared_ptr<void> ptr;
+};
+
+static void
+deinitialize(void *ptr)
+{
+    auto ptr2 = static_cast<libRef *>(ptr);
+    delete ptr2;
+}
+
+Napi::Object
+Init(Napi::Env env, Napi::Object exports)
+{
+    std::shared_ptr<void> ref = getLibRef(env);
+    if (ref == nullptr)
+    {
+        // getLibRef threw an error
+        return exports;
+    }
+
+    // Future: Once targetting node-api v6, this libRef flow can be replaced with instanceData
+    napi_add_env_cleanup_hook(env, deinitialize, new libRef{ref});
+
+    exports.Set("HID", HID::Initialize(env));
+    exports.Set("HIDAsync", HIDAsync::Initialize(env));
+    // exports.Set("devices", Napi::Function::New(env, &HID::devices));
+
+    return exports;
+}
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -22,7 +22,7 @@ deinitialize(void *ptr)
 Napi::Object
 Init(Napi::Env env, Napi::Object exports)
 {
-    std::shared_ptr<void> ref = getLibRef();
+    std::shared_ptr<void> ref = getAppCtx();
     if (ref == nullptr)
     {
         Napi::TypeError::New(env, "cannot initialize hidapi (hid_init failed)").ThrowAsJavaScriptException();
@@ -34,7 +34,9 @@ Init(Napi::Env env, Napi::Object exports)
 
     exports.Set("HID", HID::Initialize(env));
     exports.Set("HIDAsync", HIDAsync::Initialize(env));
+
     exports.Set("devices", Napi::Function::New(env, &devices));
+    exports.Set("devicesAsync", Napi::Function::New(env, &devicesAsync));
 
     return exports;
 }

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -6,44 +6,36 @@
 #include "HIDAsync.h"
 #include "devices.h"
 
-struct libRef
-{
-    // Wrap a shared_ptr in a struct we can use a normal pointer
-    std::shared_ptr<void> ptr;
-
-    Napi::FunctionReference asyncCtor;
-};
-
 static void
 deinitialize(void *ptr)
 {
-    auto ptr2 = static_cast<libRef *>(ptr);
+    auto ptr2 = static_cast<ContextState *>(ptr);
     delete ptr2;
 }
 
 Napi::Object
 Init(Napi::Env env, Napi::Object exports)
 {
-    std::shared_ptr<void> ref = getAppCtx();
-    if (ref == nullptr)
+    std::shared_ptr<ApplicationContext> appCtx = ApplicationContext::get();
+    if (appCtx == nullptr)
     {
         Napi::TypeError::New(env, "cannot initialize hidapi (hid_init failed)").ThrowAsJavaScriptException();
         return exports;
     }
 
-    auto ctor = Napi::Persistent(HIDAsync::Initialize(env));
+    auto ctor = HIDAsync::Initialize(env);
 
-    // Future: Once targetting node-api v6, this libRef flow can be replaced with instanceData
-    auto ref2 = new libRef{ref, std::move(ctor)};
-    napi_add_env_cleanup_hook(env, deinitialize, ref2);
+    // Future: Once targetting node-api v6, this ContextState flow can be replaced with instanceData
+    auto context = new ContextState(appCtx, Napi::Persistent(ctor));
+    napi_add_env_cleanup_hook(env, deinitialize, context);
 
     exports.Set("HID", HID::Initialize(env));
-    // exports.Set("HIDAsync", ctor);
+    exports.Set("HIDAsync", ctor);
 
-    exports.Set("openAsyncHIDDevice", Napi::Function::New(env, &HIDAsync::Create, nullptr, &ref2->asyncCtor)); // TODO: verify asyncCtor will be alive long enough
+    exports.Set("openAsyncHIDDevice", Napi::Function::New(env, &HIDAsync::Create, nullptr, context)); // TODO: verify context will be alive long enough
 
     exports.Set("devices", Napi::Function::New(env, &devices));
-    exports.Set("devicesAsync", Napi::Function::New(env, &devicesAsync));
+    exports.Set("devicesAsync", Napi::Function::New(env, &devicesAsync, nullptr, context)); // TODO: verify context will be alive long enough
 
     return exports;
 }

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -4,6 +4,7 @@
 
 #include "HID.h"
 #include "HIDAsync.h"
+#include "devices.h"
 
 struct libRef
 {
@@ -33,7 +34,7 @@ Init(Napi::Env env, Napi::Object exports)
 
     exports.Set("HID", HID::Initialize(env));
     exports.Set("HIDAsync", HIDAsync::Initialize(env));
-    // exports.Set("devices", Napi::Function::New(env, &HID::devices));
+    exports.Set("devices", Napi::Function::New(env, &devices));
 
     return exports;
 }

--- a/src/powermate.js
+++ b/src/powermate.js
@@ -35,7 +35,7 @@ function PowerMate(index)
     this.hid = new HID.HID(powerMates[index].path);
     this.position = 0;
     this.button = 0;
-    this.hid.read(this.interpretData.bind(this));
+    this.hid.on('data', this.interpretData.bind(this))
 }
 
 util.inherits(PowerMate, events.EventEmitter);
@@ -44,7 +44,7 @@ PowerMate.prototype.setLed = function(brightness) {
     this.hid.write([0, brightness]);
 }
 
-PowerMate.prototype.interpretData = function(error, data) {
+PowerMate.prototype.interpretData = function(data) {
     var button = data[0];
     if (button ^ this.button) {
         this.emit(button ? 'buttonDown' : 'buttonUp');
@@ -58,7 +58,6 @@ PowerMate.prototype.interpretData = function(error, data) {
         this.position += delta;
         this.emit('turn', delta, this.position);
     }
-    this.hid.read(this.interpretData.bind(this));
 }
 
 exports.PowerMate = PowerMate;

--- a/src/read.cc
+++ b/src/read.cc
@@ -1,0 +1,97 @@
+#include "read.h"
+
+struct ReadCallbackProps
+{
+    unsigned char *buf;
+    int len;
+};
+
+static void ReadCallback(Napi::Env env, Napi::Function jsCallback, ReadCallbackProps *data)
+{
+    auto buffer = Napi::Buffer<unsigned char>::New(env, data->buf, data->len, deleteArray);
+    // buf is now owned by the buffer
+    delete data;
+
+    jsCallback.Call({env.Null(), buffer});
+};
+static void ReadErrorCallback(Napi::Env env, Napi::Function jsCallback, void *data)
+{
+    auto error = Napi::String::New(env, "could not read from HID device");
+
+    jsCallback.Call({error, env.Null()});
+};
+
+ReadHelper::ReadHelper(std::shared_ptr<WrappedHidHandle> hidHandle)
+{
+    _hidHandle = hidHandle;
+}
+ReadHelper::~ReadHelper()
+{
+    stop();
+}
+
+void ReadHelper::stop()
+{
+    run_read = false;
+
+    if (read_thread.joinable())
+    {
+        read_thread.join();
+    }
+}
+
+void ReadHelper::start(Napi::Env env, Napi::Function callback)
+{
+    // If the read is already running, then abort
+    if (run_read)
+        return;
+    run_read = true;
+
+    read_callback = Napi::ThreadSafeFunction::New(
+        env,
+        callback,        // JavaScript function called asynchronously
+        "HID:read",      // Name
+        0,               // Unlimited queue
+        1,               // Only one thread will use this initially
+        [=](Napi::Env) { // Finalizer used to clean threads up
+                         // Wait for end of the thread, if it wasnt the one to close up
+            if (read_thread.joinable())
+            {
+                read_thread.join();
+            }
+        });
+
+    read_thread = std::thread([=]()
+                              {
+                              int mswait = 50;
+                              int len = 0;
+                              unsigned char *buf = new unsigned char[READ_BUFF_MAXSIZE];
+
+                              run_read = true;
+                              while (run_read)
+                              {
+                                len = hid_read_timeout(_hidHandle->hid, buf, READ_BUFF_MAXSIZE, mswait);
+                                if (len < 0)
+                                {
+                                  // Emit and error and stop reading
+                                  read_callback.BlockingCall((void *)nullptr, ReadErrorCallback);
+                                  break;
+                                }
+                                else if (len > 0)
+                                {
+                                  auto data = new ReadCallbackProps;
+                                  data->buf = buf;
+                                  data->len = len;
+
+                                  read_callback.BlockingCall(data, ReadCallback);
+                                  // buf is now owned by ReadCallback
+                                  buf = new unsigned char[READ_BUFF_MAXSIZE];
+                                }
+                              }
+
+                              run_read = false;
+                              delete[] buf;
+
+                              // Cleanup the function
+                              read_callback.Release(); });
+}

--- a/src/read.cc
+++ b/src/read.cc
@@ -8,7 +8,7 @@ struct ReadCallbackProps
 
 static void ReadCallback(Napi::Env env, Napi::Function jsCallback, ReadCallbackProps *data)
 {
-    auto buffer = Napi::Buffer<unsigned char>::New(env, data->buf, data->len, deleteArray);
+    auto buffer = convertToNodeOwnerBuffer(env, data->buf, data->len);
     // buf is now owned by the buffer
     delete data;
 

--- a/src/read.cc
+++ b/src/read.cc
@@ -21,7 +21,7 @@ static void ReadErrorCallback(Napi::Env env, Napi::Function jsCallback, void *da
     jsCallback.Call({error, env.Null()});
 };
 
-ReadHelper::ReadHelper(std::shared_ptr<WrappedHidHandle> hidHandle)
+ReadHelper::ReadHelper(std::shared_ptr<DeviceContext> hidHandle)
 {
     _hidHandle = hidHandle;
 }

--- a/src/read.h
+++ b/src/read.h
@@ -9,7 +9,7 @@
 class ReadHelper
 {
 public:
-    ReadHelper(std::shared_ptr<WrappedHidHandle> hidHandle);
+    ReadHelper(std::shared_ptr<DeviceContext> hidHandle);
     ~ReadHelper();
 
     void start(Napi::Env env, Napi::Function callback);
@@ -18,7 +18,7 @@ public:
     std::atomic<bool> run_read = {false};
 
 private:
-    std::shared_ptr<WrappedHidHandle> _hidHandle;
+    std::shared_ptr<DeviceContext> _hidHandle;
     Napi::ThreadSafeFunction read_callback;
     std::thread read_thread;
 };

--- a/src/read.h
+++ b/src/read.h
@@ -1,0 +1,21 @@
+#include "util.h"
+
+#include <thread>
+#include <atomic>
+
+class ReadHelper
+{
+public:
+    ReadHelper(std::shared_ptr<WrappedHidHandle> hidHandle);
+    ~ReadHelper();
+
+    void start(Napi::Env env, Napi::Function callback);
+    void stop();
+
+    std::atomic<bool> run_read = {false};
+
+private:
+    std::shared_ptr<WrappedHidHandle> _hidHandle;
+    Napi::ThreadSafeFunction read_callback;
+    std::thread read_thread;
+};

--- a/src/read.h
+++ b/src/read.h
@@ -1,3 +1,6 @@
+#ifndef NODEHID_READ_H__
+#define NODEHID_READ_H__
+
 #include "util.h"
 
 #include <thread>
@@ -19,3 +22,5 @@ private:
     Napi::ThreadSafeFunction read_callback;
     std::thread read_thread;
 };
+
+#endif // NODEHID_READ_H__

--- a/src/test-ps3-rumbleled.js
+++ b/src/test-ps3-rumbleled.js
@@ -36,14 +36,11 @@ function setRumbleLed(hidDevice, rumbleL, rumbleR, led_cmd )
     ]);
 }
 
-hid.gotData = function (err, data) {
+hid.on('data', (data) => {
     console.log('got ps3 data', data);
     // map left & right d-pad to rumble, and right action buttons to LEDs
     setRumbleLed( hid, data[15], data[17], data[3]>>3 );
-    this.read(this.gotData.bind(this));
-};
-
-hid.read(hid.gotData.bind(hid));
+})
 
 /*
  * data is 48-byte Buffer with byte values:

--- a/src/test-ps3.js
+++ b/src/test-ps3.js
@@ -6,11 +6,8 @@ var hid = new HID.HID(1356, 616);
 
 console.log('features', hid.getFeatureReport(0xf2, 17));
 
-hid.gotData = function (err, data) {
+hid.on('data', (data) => {
     console.log('got ps3 data', data);
-    this.read(this.gotData.bind(this));
-}
-
-hid.read(hid.gotData.bind(hid));
+})
 
 repl.context.hid = hid;

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include "util.h"
 
 // Ensure hid_init/hid_exit is coordinated across all threads
@@ -47,6 +49,17 @@ void deleteArray(const Napi::Env &env, unsigned char *ptr)
 Napi::Buffer<unsigned char> convertToNodeOwnerBuffer(const Napi::Env &env, unsigned char *ptr, size_t len)
 {
     return Napi::Buffer<unsigned char>::New(env, ptr, len, deleteArray);
+}
+
+std::string narrow(wchar_t *wide)
+{
+    std::wstring ws(wide);
+    std::ostringstream os;
+    for (size_t i = 0; i < ws.size(); i++)
+    {
+        os << os.narrow(ws[i], '?');
+    }
+    return os.str();
 }
 
 std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsigned char> &message)

--- a/src/util.cc
+++ b/src/util.cc
@@ -95,11 +95,12 @@ std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsi
     }
 }
 
-WrappedHidHandle::WrappedHidHandle(std::shared_ptr<void> libRef, hid_device *hidHandle) : AsyncWorkerQueue(), hid(hidHandle), libRef(libRef) {}
+WrappedHidHandle::WrappedHidHandle(std::shared_ptr<ApplicationContext> appCtx, hid_device *hidHandle) : AsyncWorkerQueue(), hid(hidHandle), appCtx(appCtx) {}
 WrappedHidHandle::~WrappedHidHandle()
 {
     if (hid)
     {
+        // We shouldn't ever get here, but lets make sure it was freed
         hid_close(hid);
         hid = nullptr;
     }

--- a/src/util.cc
+++ b/src/util.cc
@@ -5,6 +5,11 @@ void deleteArray(const Napi::Env &env, unsigned char *ptr)
     delete[] ptr;
 }
 
+Napi::Buffer<unsigned char> convertToNodeOwnerBuffer(const Napi::Env &env, unsigned char *ptr, size_t len)
+{
+    return Napi::Buffer<unsigned char>::New(env, ptr, len, deleteArray);
+}
+
 std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsigned char> &message)
 {
     if (val.IsBuffer())

--- a/src/util.cc
+++ b/src/util.cc
@@ -94,11 +94,6 @@ std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsi
     }
 }
 
-ContextState::ContextState(std::shared_ptr<ApplicationContext> appCtx, Napi::FunctionReference asyncCtor) : AsyncWorkerQueue(), appCtx(appCtx), asyncCtor(std::move(asyncCtor)) {}
-
-DeviceContext::DeviceContext(std::shared_ptr<ApplicationContext> appCtx, hid_device *hidHandle) : AsyncWorkerQueue(), hid(hidHandle), appCtx(appCtx)
-{
-}
 DeviceContext::~DeviceContext()
 {
     if (hid)

--- a/src/util.cc
+++ b/src/util.cc
@@ -17,7 +17,7 @@ static void releaseLib(void *)
     }
 }
 
-std::shared_ptr<void> getLibRef(const Napi::Env &env)
+std::shared_ptr<void> getLibRef()
 {
     {
         // Make sure we run init on only one thread
@@ -29,7 +29,6 @@ std::shared_ptr<void> getLibRef(const Napi::Env &env)
             // Not initialised, so lets do that
             if (hid_init())
             {
-                Napi::TypeError::New(env, "cannot initialize hidapi (hid_init failed)").ThrowAsJavaScriptException();
                 return nullptr;
             }
 
@@ -85,7 +84,7 @@ std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsi
     }
 }
 
-WrappedHidHandle::WrappedHidHandle(hid_device *hidHandle) : hid(hidHandle) {}
+WrappedHidHandle::WrappedHidHandle(std::shared_ptr<void> libRef, hid_device *hidHandle) : hid(hidHandle), libRef(libRef) {}
 WrappedHidHandle::~WrappedHidHandle()
 {
     if (hid)

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,0 +1,83 @@
+#include "util.h"
+
+void deleteArray(const Napi::Env &env, unsigned char *ptr)
+{
+    delete[] ptr;
+}
+
+std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsigned char> &message)
+{
+    if (val.IsBuffer())
+    {
+        Napi::Buffer<unsigned char> buffer = val.As<Napi::Buffer<unsigned char>>();
+        uint32_t len = buffer.Length();
+        unsigned char *data = buffer.Data();
+        message.assign(data, data + len);
+
+        return "";
+    }
+    else if (val.IsArray())
+    {
+        Napi::Array messageArray = val.As<Napi::Array>();
+        message.reserve(messageArray.Length());
+
+        for (unsigned i = 0; i < messageArray.Length(); i++)
+        {
+            Napi::Value v = messageArray.Get(i);
+            if (!v.IsNumber())
+            {
+                return "unexpected array element in array to send, expecting only integers";
+            }
+            uint32_t b = v.As<Napi::Number>().Uint32Value();
+            message.push_back((unsigned char)b);
+        }
+
+        return "";
+    }
+    else
+    {
+        return "unexpected data to send, expecting an array or buffer";
+    }
+}
+
+WrappedHidHandle::WrappedHidHandle(hid_device *hidHandle) : hid(hidHandle) {}
+WrappedHidHandle::~WrappedHidHandle()
+{
+    if (hid)
+    {
+        hid_close(hid);
+        hid = nullptr;
+    }
+
+    // TODO - discard the jobQueue in a safe manner
+}
+
+void WrappedHidHandle::QueueJob(const Napi::Env &, Napi::AsyncWorker *job)
+{
+    std::unique_lock<std::mutex> lock(jobQueueMutex);
+    if (!isRunning)
+    {
+        isRunning = true;
+        job->Queue();
+    }
+    else
+    {
+        jobQueue.push(job);
+    }
+}
+
+void WrappedHidHandle::JobFinished(const Napi::Env &)
+{
+    std::unique_lock<std::mutex> lock(jobQueueMutex);
+
+    if (jobQueue.size() == 0)
+    {
+        isRunning = false;
+    }
+    else
+    {
+        auto newJob = jobQueue.front();
+        jobQueue.pop();
+        newJob->Queue();
+    }
+}

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,4 +1,6 @@
 #include <sstream>
+#include <locale>
+#include <codecvt>
 
 #include "util.h"
 
@@ -38,15 +40,14 @@ std::shared_ptr<ApplicationContext> ApplicationContext::get()
     return ref;
 }
 
-std::string narrow(wchar_t *wide)
+std::string utf8_encode(const std::wstring &source)
 {
-    std::wstring ws(wide);
-    std::ostringstream os;
-    for (size_t i = 0; i < ws.size(); i++)
-    {
-        os << os.narrow(ws[i], '?');
-    }
-    return os.str();
+    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(source);
+}
+
+std::wstring utf8_decode(const std::string &source)
+{
+    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(source);
 }
 
 std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsigned char> &message)

--- a/src/util.h
+++ b/src/util.h
@@ -10,8 +10,6 @@
 
 #define READ_BUFF_MAXSIZE 2048
 
-std::shared_ptr<void> getLibRef();
-
 Napi::Buffer<unsigned char> convertToNodeOwnerBuffer(const Napi::Env &env, unsigned char *ptr, size_t len);
 
 std::string narrow(wchar_t *wide);
@@ -22,12 +20,11 @@ std::string narrow(wchar_t *wide);
  */
 std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsigned char> &message);
 
-class WrappedHidHandle
+class AsyncWorkerQueue
 {
-public:
-    WrappedHidHandle(std::shared_ptr<void> libRef, hid_device *hidHandle);
-    ~WrappedHidHandle();
+    // TODO - discard the jobQueue in a safe manner
 
+public:
     /**
      * Push a job onto the queue.
      * Note: This must only be run from the main thread
@@ -40,14 +37,80 @@ public:
      */
     void JobFinished(const Napi::Env &);
 
+private:
+    bool isRunning = false;
+    std::queue<Napi::AsyncWorker *> jobQueue;
+    std::mutex jobQueueMutex;
+};
+
+class WrappedHidHandle : public AsyncWorkerQueue
+{
+public:
+    WrappedHidHandle(std::shared_ptr<void> libRef, hid_device *hidHandle);
+    ~WrappedHidHandle();
+
     hid_device *hid;
 
 private:
     std::shared_ptr<void> libRef;
+};
 
-    bool isRunning = false;
-    std::queue<Napi::AsyncWorker *> jobQueue;
-    std::mutex jobQueueMutex;
+class ApplicationContext : public AsyncWorkerQueue
+{
+public:
+    ~ApplicationContext();
+
+    // A lock for any enumerate/open operations, as they are not thread safe
+    // In async land, these are also done in a single-threaded queue, this lock is used to link up with the sync side
+    std::mutex enumerateLock;
+};
+
+std::shared_ptr<ApplicationContext> getAppCtx();
+
+template <class T>
+class PromiseAsyncWorker : public Napi::AsyncWorker
+{
+public:
+    PromiseAsyncWorker(
+        const Napi::Env &env, std::shared_ptr<T> queue)
+        : Napi::AsyncWorker(env),
+          queue(queue),
+          deferred(Napi::Promise::Deferred::New(env))
+    {
+    }
+
+    // This code will be executed on the worker thread. Note: Napi types cannot be used
+    virtual void Execute() override;
+
+    virtual Napi::Value GetResult(const Napi::Env &env) = 0;
+
+    void OnOK() override
+    {
+        Napi::Env env = Env();
+        queue->JobFinished(env);
+
+        deferred.Resolve(GetResult(env));
+    }
+    void OnError(Napi::Error const &error) override
+    {
+        queue->JobFinished(Env());
+        deferred.Reject(error.Value());
+    }
+
+    Napi::Promise QueueAndRun()
+    {
+        auto promise = deferred.Promise();
+
+        queue->QueueJob(Env(), this);
+
+        return promise;
+    }
+
+protected:
+    std::shared_ptr<T> queue;
+
+private:
+    Napi::Promise::Deferred deferred;
 };
 
 #endif // NODEHID_UTIL_H__

--- a/src/util.h
+++ b/src/util.h
@@ -114,9 +114,13 @@ public:
     void OnOK() override
     {
         Napi::Env env = Env();
+
+        // Collect the result before finishing the job, in case the result relies on the hid object
+        Napi::Value result = GetResult(env);
+
         context->JobFinished(env);
 
-        deferred.Resolve(GetResult(env));
+        deferred.Resolve(result);
     }
     void OnError(Napi::Error const &error) override
     {

--- a/src/util.h
+++ b/src/util.h
@@ -20,7 +20,6 @@ public:
     WrappedHidHandle(hid_device *hidHandle);
     ~WrappedHidHandle();
     hid_device *hid;
-    std::mutex hidLock;
 
     /**
      * Push a job onto the queue.

--- a/src/util.h
+++ b/src/util.h
@@ -69,7 +69,7 @@ private:
 class ContextState : public AsyncWorkerQueue
 {
 public:
-    ContextState(std::shared_ptr<ApplicationContext> appCtx, Napi::FunctionReference asyncCtor);
+    ContextState(std::shared_ptr<ApplicationContext> appCtx, Napi::FunctionReference asyncCtor) : AsyncWorkerQueue(), appCtx(appCtx), asyncCtor(std::move(asyncCtor)) {}
 
     // Keep the ApplicationContext alive for longer than this state
     std::shared_ptr<ApplicationContext> appCtx;
@@ -81,7 +81,10 @@ public:
 class DeviceContext : public AsyncWorkerQueue
 {
 public:
-    DeviceContext(std::shared_ptr<ApplicationContext> appCtx, hid_device *hid);
+    DeviceContext(std::shared_ptr<ApplicationContext> appCtx, hid_device *hidHandle) : AsyncWorkerQueue(), hid(hidHandle), appCtx(appCtx)
+    {
+    }
+
     ~DeviceContext();
 
     hid_device *hid;

--- a/src/util.h
+++ b/src/util.h
@@ -10,8 +10,12 @@
 
 #define READ_BUFF_MAXSIZE 2048
 
-void deleteArray(const Napi::Env &env, unsigned char *ptr);
+Napi::Buffer<unsigned char> convertToNodeOwnerBuffer(const Napi::Env &env, unsigned char *ptr, size_t len);
 
+/**
+ * Convert a js value (either a buffer ot array of numbers) into a vector of bytes.
+ * Returns a non-empty string upon failure
+ */
 std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsigned char> &message);
 
 class WrappedHidHandle

--- a/src/util.h
+++ b/src/util.h
@@ -14,6 +14,8 @@ std::shared_ptr<void> getLibRef();
 
 Napi::Buffer<unsigned char> convertToNodeOwnerBuffer(const Napi::Env &env, unsigned char *ptr, size_t len);
 
+std::string narrow(wchar_t *wide);
+
 /**
  * Convert a js value (either a buffer ot array of numbers) into a vector of bytes.
  * Returns a non-empty string upon failure

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,43 @@
+#ifndef NODEHID_UTIL_H__
+#define NODEHID_UTIL_H__
+
+#define NAPI_VERSION 4
+#include <napi.h>
+
+#include <queue>
+
+#include <hidapi.h>
+
+#define READ_BUFF_MAXSIZE 2048
+
+void deleteArray(const Napi::Env &env, unsigned char *ptr);
+
+std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsigned char> &message);
+
+class WrappedHidHandle
+{
+public:
+    WrappedHidHandle(hid_device *hidHandle);
+    ~WrappedHidHandle();
+    hid_device *hid;
+    std::mutex hidLock;
+
+    /**
+     * Push a job onto the queue.
+     * Note: This must only be run from the main thread
+     */
+    void QueueJob(const Napi::Env &, Napi::AsyncWorker *job);
+
+    /**
+     * The job has finished, start the next in the queue.
+     * Note: This must only be run from the main thread
+     */
+    void JobFinished(const Napi::Env &);
+
+private:
+    bool isRunning = false;
+    std::queue<Napi::AsyncWorker *> jobQueue;
+    std::mutex jobQueueMutex;
+};
+
+#endif // NODEHID_UTIL_H__

--- a/src/util.h
+++ b/src/util.h
@@ -10,7 +10,8 @@
 
 #define READ_BUFF_MAXSIZE 2048
 
-std::string narrow(wchar_t *wide);
+std::string utf8_encode(const std::wstring &source);
+std::wstring utf8_decode(const std::string &source);
 
 /**
  * Convert a js value (either a buffer ot array of numbers) into a vector of bytes.
@@ -37,6 +38,8 @@ public:
 class AsyncWorkerQueue
 {
     // TODO - discard the jobQueue in a safe manner
+    // there should be a destructor which ensures that the queue is empty
+    // when we 'unref' it from the parent, we should mark it as dead, and tell any remaining workers to abort
 
 public:
     /**

--- a/src/util.h
+++ b/src/util.h
@@ -10,6 +10,8 @@
 
 #define READ_BUFF_MAXSIZE 2048
 
+std::shared_ptr<void> getLibRef(const Napi::Env &env);
+
 Napi::Buffer<unsigned char> convertToNodeOwnerBuffer(const Napi::Env &env, unsigned char *ptr, size_t len);
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -67,8 +67,7 @@ public:
 
 private:
     // Hold a reference to the ApplicationContext,
-    std::shared_ptr<ApplicationContext>
-        appCtx;
+    std::shared_ptr<ApplicationContext> appCtx;
 };
 
 template <class T>
@@ -84,7 +83,7 @@ public:
     }
 
     // This code will be executed on the worker thread. Note: Napi types cannot be used
-    virtual void Execute() override;
+    virtual void Execute() override = 0;
 
     virtual Napi::Value GetResult(const Napi::Env &env) = 0;
 

--- a/src/util.h
+++ b/src/util.h
@@ -43,18 +43,6 @@ private:
     std::mutex jobQueueMutex;
 };
 
-class WrappedHidHandle : public AsyncWorkerQueue
-{
-public:
-    WrappedHidHandle(std::shared_ptr<void> libRef, hid_device *hidHandle);
-    ~WrappedHidHandle();
-
-    hid_device *hid;
-
-private:
-    std::shared_ptr<void> libRef;
-};
-
 class ApplicationContext : public AsyncWorkerQueue
 {
 public:
@@ -66,6 +54,19 @@ public:
 };
 
 std::shared_ptr<ApplicationContext> getAppCtx();
+
+class WrappedHidHandle : public AsyncWorkerQueue
+{
+public:
+    WrappedHidHandle(std::shared_ptr<ApplicationContext> appCtx, hid_device *hidHandle);
+    ~WrappedHidHandle();
+
+    hid_device *hid;
+
+private:
+    // Hold a reference to the ApplicationContext,
+    std::shared_ptr<ApplicationContext> appCtx;
+};
 
 template <class T>
 class PromiseAsyncWorker : public Napi::AsyncWorker

--- a/src/util.h
+++ b/src/util.h
@@ -63,9 +63,12 @@ public:
 
     hid_device *hid;
 
+    bool is_closed = false;
+
 private:
     // Hold a reference to the ApplicationContext,
-    std::shared_ptr<ApplicationContext> appCtx;
+    std::shared_ptr<ApplicationContext>
+        appCtx;
 };
 
 template <class T>

--- a/src/util.h
+++ b/src/util.h
@@ -10,7 +10,7 @@
 
 #define READ_BUFF_MAXSIZE 2048
 
-std::shared_ptr<void> getLibRef(const Napi::Env &env);
+std::shared_ptr<void> getLibRef();
 
 Napi::Buffer<unsigned char> convertToNodeOwnerBuffer(const Napi::Env &env, unsigned char *ptr, size_t len);
 
@@ -23,9 +23,8 @@ std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsi
 class WrappedHidHandle
 {
 public:
-    WrappedHidHandle(hid_device *hidHandle);
+    WrappedHidHandle(std::shared_ptr<void> libRef, hid_device *hidHandle);
     ~WrappedHidHandle();
-    hid_device *hid;
 
     /**
      * Push a job onto the queue.
@@ -39,7 +38,11 @@ public:
      */
     void JobFinished(const Napi::Env &);
 
+    hid_device *hid;
+
 private:
+    std::shared_ptr<void> libRef;
+
     bool isRunning = false;
     std::queue<Napi::AsyncWorker *> jobQueue;
     std::mutex jobQueueMutex;


### PR DESCRIPTION
Closes #132

This expands on #474 with some new functionality. I thought it better to do as a separate PR to avoid making #474 even larger.

Only the last couple of commits are relevant here, once #474 is merged the changes involved here will become a lot clearer.

This update hidapi to 0.13.1, and uses the new `hid_get_device_info` method to add more properties to the `getDeviceInfo` methods. `getDeviceInfo` will now return the same content as is provided by a call to `HID.devices()`.

My usecase for this is that in https://github.com/Julusian/node-elgato-stream-deck I need to know what model of streamdeck a given path corresponds to. Until now I have achieved this by making a call to `HID.devices()`, and finding the entry with a matching path to find the productId and vendorId. This is unsurprisingly not at all efficient as it requires enumerating devices every time a new device is opened.  
Instead this will let me open the device, and retrieve the ids directly from it. 

@todbot I vaguely remember reading something about concerns or things that need testing with updating hidapi. Do you know of anything that is particularly at risk of being an issue? On linux (hidraw) it was a drop in replacement that appears to work fine without additional changes.

Until this is merged it is possible to test with https://www.npmjs.com/package/@julusian/hid. You can either import it explicitly, or with `"node-hid": "npm:@julusian/hid@^3.0.0-0"`, to alias it to the `node-hid` name. This includes the changes from #474, #490 and #499.