### PR TITLE
Fix generateDeviceInfo type

### DIFF
--- a/nodehid.d.ts
+++ b/nodehid.d.ts
@@ -33,7 +33,7 @@ export class HID extends EventEmitter {
     resume(): void
     write(values: number[] | Buffer): number
     setNonBlocking(no_block: boolean): void
-    generateDeviceInfo(): Device
+    getDeviceInfo(): Device
 }
 export function devices(vid: number, pid: number): Device[]
 export function devices(): Device[]


### PR DESCRIPTION
The HID object contains a function "getDeviceInfo", but the type definition declared it as "generateDeviceInfo", which causes a compilation error.

This commit only renames the exposed function's name to getDeviceInfo.

```
HID {
  _events: [Object: null prototype] { newListener: [Function (anonymous)] },
  _eventsCount: 1,
  _maxListeners: undefined,
  _raw: HID {},
  write: [Function: bound write],
  getFeatureReport: [Function: bound getFeatureReport],
  sendFeatureReport: [Function: bound sendFeatureReport],
  setNonBlocking: [Function: bound setNonBlocking],
  readSync: [Function: bound readSync],
  readTimeout: [Function: bound readTimeout],
  getDeviceInfo: [Function: bound getDeviceInfo],
  _paused: true,
  [Symbol(kCapture)]: false
}
```