### PR TITLE
fix: crash when closing async read thread

### DIFF
--- a/src/HIDAsync.h
+++ b/src/HIDAsync.h
@@ -13,7 +13,7 @@ public:
 
 private:
     std::shared_ptr<DeviceContext> _hidHandle;
-    std::unique_ptr<ReadHelper> helper;
+    std::shared_ptr<ReadThreadState> read_state;
 
     void closeHandle();
 

--- a/src/read.cc
+++ b/src/read.cc
@@ -1,97 +1,151 @@
 #include "read.h"
 
+struct ReadCallbackContext;
+
 struct ReadCallbackProps
 {
     unsigned char *buf;
     int len;
 };
 
-static void ReadCallback(Napi::Env env, Napi::Function jsCallback, ReadCallbackProps *data)
-{
-    auto buffer = Napi::Buffer<unsigned char>::Copy(env, data->buf, data->len);
-    delete data->buf;
-    delete data;
+using Context = ReadCallbackContext;
+using DataType = ReadCallbackProps;
+void ReadCallback(Napi::Env env, Napi::Function callback, Context *context, DataType *data);
+using TSFN = Napi::TypedThreadSafeFunction<Context, DataType, ReadCallback>;
+using FinalizerDataType = void;
 
-    jsCallback.Call({env.Null(), buffer});
+struct ReadCallbackContext
+{
+    std::shared_ptr<ReadThreadState> state;
+
+    std::shared_ptr<DeviceContext> _hidHandle;
+    std::thread read_thread;
+
+    TSFN read_callback;
 };
-static void ReadErrorCallback(Napi::Env env, Napi::Function jsCallback, void *data)
-{
-    auto error = Napi::String::New(env, "could not read from HID device");
 
-    jsCallback.Call({error, env.Null()});
-};
-
-ReadHelper::ReadHelper(std::shared_ptr<DeviceContext> hidHandle)
+void ReadCallback(Napi::Env env, Napi::Function callback, Context *context, DataType *data)
 {
-    _hidHandle = hidHandle;
-}
-ReadHelper::~ReadHelper()
-{
-    stop_and_join();
-}
-
-void ReadHelper::stop_and_join()
-{
-    run_read = false;
-
-    if (read_thread.joinable())
+    if (env != nullptr && callback != nullptr) //&& context != nullptr)
     {
-        read_thread.join();
+        if (data == nullptr)
+        {
+            auto error = Napi::String::New(env, "could not read from HID device");
+
+            callback.Call({error, env.Null()});
+        }
+        else
+        {
+            auto buffer = Napi::Buffer<unsigned char>::Copy(env, data->buf, data->len);
+
+            callback.Call({env.Null(), buffer});
+        }
+    }
+
+    if (data != nullptr)
+    {
+        delete data->buf;
+        delete data;
+    }
+};
+
+bool ReadThreadState::is_running()
+{
+    std::unique_lock<std::mutex> lk(lock);
+    return running;
+}
+void ReadThreadState::wait()
+{
+    std::unique_lock<std::mutex> lk(lock);
+    if (running)
+    {
+        wait_for_end.wait(lk, [this]
+                          { return !running; });
     }
 }
 
-void ReadHelper::start(Napi::Env env, Napi::Function callback)
+void ReadThreadState::release()
 {
-    // If the read is already running, then abort
-    if (run_read)
-        return;
-    run_read = true;
+    std::unique_lock<std::mutex> lk(lock);
+    running = false;
+    wait_for_end.notify_all();
+}
 
-    read_thread = std::thread([&]()
-                              {
+/**
+ * Getting the thread safety of this correct has been challenging.
+ * There is a problem that the read thread can take 50ms to exit once run_read becomes false, and we don't want to block the event loop waiting for it.
+ * And a problem of that either the read_thread can decide to abort by itself.
+ * This means that either read_thread or the class that spawned it could outlive the other.
+ *
+ * Doing this in a class is hard, as the tsfn needs to be the one to own and free the class, but the caller needs to be able to 'ask' for an abort.
+ * This method is a simplified form, using a 'context' class whose ownership gets assigned to the tsfn, with the caller only getting the atomic<bool>
+ * to both be able to know if the loop is running and to 'ask' it to stop
+ *
+ * While this does now return a struct to handle the shared state, the tsfn and thread are importantly not on this class.
+ */
+std::shared_ptr<ReadThreadState> start_read_helper(Napi::Env env, std::shared_ptr<DeviceContext> hidHandle, Napi::Function callback)
+{
+    auto state = std::make_shared<ReadThreadState>();
+
+    auto context = new ReadCallbackContext;
+    context->state = state;
+    context->_hidHandle = std::move(hidHandle);
+
+    context->read_thread = std::thread([context]()
+                                       {
                               int mswait = 50;
                               int len = 0;
                               unsigned char *buf = new unsigned char[READ_BUFF_MAXSIZE];
 
-                              run_read = true;
-                              while (run_read)
+                              while (!context->state->abort)
                               {
-                                len = hid_read_timeout(_hidHandle->hid, buf, READ_BUFF_MAXSIZE, mswait);
+                                len = hid_read_timeout(context->_hidHandle->hid, buf, READ_BUFF_MAXSIZE, mswait);
+                                if (context->state->abort)
+                                    break;
+
                                 if (len < 0)
                                 {
-                                  // Emit and error and stop reading
-                                  read_callback.BlockingCall((void *)nullptr, ReadErrorCallback);
-                                  break;
+                                    // Emit and error and stop reading
+                                    context->read_callback.BlockingCall(nullptr);
+                                    break;
                                 }
                                 else if (len > 0)
                                 {
-                                  auto data = new ReadCallbackProps;
-                                  data->buf = buf;
-                                  data->len = len;
+                                    auto data = new ReadCallbackProps;
+                                    data->buf = buf;
+                                    data->len = len;
 
-                                  read_callback.BlockingCall(data, ReadCallback);
-                                  // buf is now owned by ReadCallback
-                                  buf = new unsigned char[READ_BUFF_MAXSIZE];
+                                    context->read_callback.BlockingCall(data);
+                                    // buf is now owned by ReadCallback
+                                    buf = new unsigned char[READ_BUFF_MAXSIZE];
                                 }
                               }
 
-                              run_read = false;
                               delete[] buf;
 
-                              // Cleanup the function
-                              read_callback.Release(); });
+                              // Mark the state and used hidHandle as released
+                              context->state->release();
 
-    read_callback = Napi::ThreadSafeFunction::New(
+                              // Cleanup the function
+                              context->read_callback.Release(); });
+
+    context->read_callback = TSFN::New(
         env,
-        callback,        // JavaScript function called asynchronously
-        "HID:read",      // Name
-        0,               // Unlimited queue
-        1,               // Only one thread will use this initially
-        [&](Napi::Env) { // Finalizer used to clean threads up
-                         // Wait for end of the thread, if it wasnt the one to close up
-            if (read_thread.joinable())
+        callback,                                 // JavaScript function called asynchronously
+        "HID:read",                               // Name
+        0,                                        // Unlimited queue
+        1,                                        // Only one thread will use this initially
+        context,                                  // Context
+        [](Napi::Env, void *, Context *context) { // Finalizer used to clean threads up
+            if (context->read_thread.joinable())
             {
-                read_thread.join();
+                // Ensure the thread has terminated
+                context->read_thread.join();
             }
+
+            // Free the context
+            delete context;
         });
+
+    return state;
 }


### PR DESCRIPTION
A crash was reported to me by a user https://github.com/bitfocus/companion/issues/2735

It turned out to be easy enough to reproduce, by pressing buttons on a streamdeck while unplugging.

As far as I can tell, it was either caused by having multiple places joining the read_thread (which is undefined behaviour), or the coordination of freeing the read_thread and tsfn.

Hopefully the new implementation clarifies the ownership of everything, primarily that the tsfn takes ownership of `context`, and while the thread also uses that, the tsfn finaliser is what frees it. The parent `HIDAsync` class does not have a reference to this, only to an additional shared state class which it can use to tell the thread to abort and to then wait for this to be done (via a condition_variable instead of a join that it used to do)

