### PR TITLE
Fix HIDAsync typings

### DIFF
--- a/nodehid.d.ts
+++ b/nodehid.d.ts
@@ -55,7 +55,7 @@ export class HIDAsync extends EventEmitter {
     resume(): void
     write(values: number[] | Buffer): Promise<number>
     setNonBlocking(no_block: boolean): Promise<void>
-    generateDeviceInfo(): Promise<Device>
+    getDeviceInfo(): Promise<Device>
 }
 
 export function setDriverType(type: 'hidraw' | 'libusb'): void


### PR DESCRIPTION
Declared generateDeviceInfo does not exist. There is getDeviceInfo like in sync variant.