### PR TITLE
chore: update pkg-prebuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   "license": "(MIT OR X11)",
   "dependencies": {
     "node-addon-api": "^3.2.1",
-    "pkg-prebuilds": "^0.2.1"
+    "pkg-prebuilds": "^1.0.0"
   },
   "devDependencies": {
-    "rimraf": "^2.6.2"
+    "rimraf": "^5.0.7"
   },
   "gypfile": true,
   "files": [


### PR DESCRIPTION
This updates pkg-prebuilds to the latest version.
Despite the version bump, this does not include a breaking change, it was simply a switch from pre-1.0 to 1.0 numbering.
The main change this includes is better error messages when it fails to find a binary to load
https://github.com/Julusian/pkg-prebuilds/compare/v0.2.1...v1.0.0?w=1

Additionally, update the rather outdated rimraf dev-dependency. While the new version doesn't support node10 (the rest of the library does), this should have little or no impact, as this is only a dev-dependency