### PR TITLE
fix: typo in error handling of HID

### DIFF
--- a/nodehid.js
+++ b/nodehid.js
@@ -119,7 +119,7 @@ HID.prototype.resume = function resume() {
             } catch (e) {
                 // Emit an error on the device instead of propagating to a c++ exception
                 setImmediate(() => {
-                    this.emit("error", e);
+                    self.emit("error", e);
                 });
             }
         });


### PR DESCRIPTION
I made a mistake in #543 (to fix #541) for the HID class, which causes errors to be misthrown when emitted by user code