### PR TITLE
chore: disable lockfile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
### Changes

- Add `.npmrc` with `package-lock=false` to disable the lock file since the project already ignored the `package-lock.json`

This can prevent npm from generating the lock file during the `install` step. So that our maintainers/contributors can have a consistent development experience with CI.