### PR TITLE
feat: add windows arm build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,16 @@ jobs:
       matrix:
         include:
           # windows
-          - os: windows-2019
+          - os: windows-2022
             arch: x64
             is-native: true
-          - os: windows-2019
+          - os: windows-2022
             arch: ia32
             is-native: false
+          - os: windows-2022
+            arch: arm64
+            is-native: false
+            node-version: 20.x # 16.x is missing the arm64 node.lib
           # macos
           - os: macos-12
             arch: arm64
@@ -70,9 +74,9 @@ jobs:
         if: runner.os == 'macOS'
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11    # ${{ matrix.python }}
+          python-version: 3.11 # ${{ matrix.python }}
         env:
-          PYTHON_VERSION: 3.11  # ${{ matrix.python }}  # Why do this?
+          PYTHON_VERSION: 3.11 # ${{ matrix.python }}  # Why do this?
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -80,10 +84,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libudev-dev libusb-1.0-0-dev
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version || '16.x' }}
 
       - name: rebuild
         if: ${{ !matrix.docker-arch }}


### PR DESCRIPTION
This adds a prebuild for windows arm64 (snapdragon cpu).

I have only tested it as far as loading the library inside a windows arm virtual machine, where it loaded without error. 