### PR TITLE
fix: HID::read can segfault if device is closed during a read

### DIFF
--- a/src/HID.h
+++ b/src/HID.h
@@ -1,5 +1,7 @@
 #include "util.h"
 
+#include <atomic>
+
 class HID : public Napi::ObjectWrap<HID>
 {
 public:
@@ -12,11 +14,15 @@ public:
 
     hid_device *_hidHandle;
 
+    std::atomic<bool> _readRunning = false;
+    std::atomic<bool> _readInterrupt = false;
+
 private:
     static Napi::Value devices(const Napi::CallbackInfo &info);
 
     Napi::Value close(const Napi::CallbackInfo &info);
     Napi::Value read(const Napi::CallbackInfo &info);
+    Napi::Value readInterrupt(const Napi::CallbackInfo &info);
     Napi::Value write(const Napi::CallbackInfo &info);
     Napi::Value setNonBlocking(const Napi::CallbackInfo &info);
     Napi::Value getFeatureReport(const Napi::CallbackInfo &info);


### PR DESCRIPTION
I've identified a crash going back to at least 2.0.0 (older is hard a lot of effort to build), which affects the sync `HID`  implementation. It looks like it could happen earlier too.
This was easy to reproduce on my linux machine, it could well affect any OS.

The HIDAsync implementation is not affected by this, as it uses a simpler 'from scratch' implementation of reading.

The basics of it is that it is not safe to be run `hid_close`  while a `hid_read_timeout` call is still running, which could easily happen.
I have made 2 changes to mitigate this:
* We track if there is a `ReadWorker` running. If it is running when close is called, the native close method will throw
* On the JS side, if the read loop is running, don't call close immediately. Instead 'interrupt' the current read, and once that returns finish up the close.


My simple reproduction was with a contour shuttle express on Fedora 41:
```
setInterval(() => {
  //   console.log("keepalive");
}, 1000);

const hid = require("..");

(async () => {
  const d = new hid.HID(0x0b33, 0x0020);
  console.log(!!d);

  d.on("data", () => {
    //
  });

  setTimeout(() => {
    console.log("closing");
    d.close();
  }, 1000);
})();
```

