### PR TITLE
fix: update build for Node.js v21+ compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,23 +48,23 @@ jobs:
             arch: x64
             is-native: true
             docker-arch: linux/amd64
-            docker-image: node:14-buster
+            docker-image: node:16-buster
           - os: ubuntu-24.04-arm
             arch: arm64
             is-native: true
             docker-arch: linux/arm64
-            docker-image: node:14-buster
+            docker-image: node:16-buster
           - os: ubuntu-24.04-arm
             arch: arm
             is-native: false
             docker-arch: linux/arm/v7
-            docker-image: node:14-buster
+            docker-image: node:16-buster
           # linux musl/alpine
           - os: ubuntu-latest
             arch: x64
             is-native: true
             docker-arch: linux/amd64
-            docker-image: node:14-alpine
+            docker-image: node:16-alpine
             libc: musl
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 build/
 node_modules
 npm-debug.log
-package-lock.json
 Release/
 prebuilds/
 *.tgz

--- a/binding.gyp
+++ b/binding.gyp
@@ -55,7 +55,6 @@
                     'msvs_settings': {
                         'VCCLCompilerTool': {
                             'ExceptionHandling': '2', # /EHsc
-                            'AdditionalOptions': ['/std:c++17'],
                             'DisableSpecificWarnings': [ '4290', '4530', '4267' ],
                         },
                         'VCLinkerTool': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -28,6 +28,7 @@
                     ],
                     'xcode_settings': {
                         'CLANG_CXX_LIBRARY': 'libc++',
+                        'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
                         'MACOSX_DEPLOYMENT_TARGET': '10.9',
                         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                         'OTHER_LDFLAGS': [
@@ -54,6 +55,7 @@
                     'msvs_settings': {
                         'VCCLCompilerTool': {
                             'ExceptionHandling': '2', # /EHsc
+                            'AdditionalOptions': ['/std:c++17'],
                             'DisableSpecificWarnings': [ '4290', '4530', '4267' ],
                         },
                         'VCLinkerTool': {
@@ -65,7 +67,7 @@
             'cflags!': ['-ansi', '-fno-exceptions' ],
             'cflags_cc!': [ '-fno-exceptions' ],
             'cflags': ['-g', '-exceptions'],
-            'cflags_cc': ['-g', '-exceptions']
+            'cflags_cc': ['-g', '-exceptions', '-std=c++17']
         }, # target HID
 
         {
@@ -152,7 +154,7 @@
                     'cflags!': ['-ansi', '-fno-exceptions' ],
                     'cflags_cc!': [ '-fno-exceptions' ],
                     'cflags': ['-g', '-exceptions'],
-                    'cflags_cc': ['-g', '-exceptions']
+                    'cflags_cc': ['-g', '-exceptions', '-std=c++17']
                 }, # target 'HID-hidraw'
 
                 {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "license": "(MIT OR X11)",
   "dependencies": {
-    "node-addon-api": "^3.2.1",
+    "node-addon-api": "^8.8.0",
     "pkg-prebuilds": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-hid",
   "description": "USB HID device access library",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "author": "Hans Hübner <hans.huebner@gmail.com> (https://github.com/hanshuebner)",
   "bugs": "https://github.com/node-hid/node-hid/issues",
   "homepage": "https://github.com/node-hid/node-hid#readme",

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,6 +1,4 @@
 #include <sstream>
-#include <locale>
-#include <codecvt>
 
 #include "util.h"
 
@@ -42,12 +40,86 @@ std::shared_ptr<ApplicationContext> ApplicationContext::get()
 
 std::string utf8_encode(const std::wstring &source)
 {
-    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(source);
+    std::string result;
+    for (size_t i = 0; i < source.size(); ) {
+        uint32_t cp;
+        wchar_t wc = source[i++];
+#ifdef _WIN32
+        // wchar_t is UTF-16 on Windows; handle surrogate pairs
+        if (wc >= 0xD800 && wc <= 0xDBFF && i < source.size()) {
+            wchar_t wc2 = source[i];
+            if (wc2 >= 0xDC00 && wc2 <= 0xDFFF) {
+                cp = 0x10000u + ((static_cast<uint32_t>(wc - 0xD800) << 10) | (wc2 - 0xDC00));
+                i++;
+            } else {
+                cp = static_cast<uint32_t>(wc);
+            }
+        } else {
+            cp = static_cast<uint32_t>(wc);
+        }
+#else
+        cp = static_cast<uint32_t>(wc);
+#endif
+        if (cp < 0x80u) {
+            result += static_cast<char>(cp);
+        } else if (cp < 0x800u) {
+            result += static_cast<char>(0xC0u | (cp >> 6));
+            result += static_cast<char>(0x80u | (cp & 0x3Fu));
+        } else if (cp < 0x10000u) {
+            result += static_cast<char>(0xE0u | (cp >> 12));
+            result += static_cast<char>(0x80u | ((cp >> 6) & 0x3Fu));
+            result += static_cast<char>(0x80u | (cp & 0x3Fu));
+        } else {
+            result += static_cast<char>(0xF0u | (cp >> 18));
+            result += static_cast<char>(0x80u | ((cp >> 12) & 0x3Fu));
+            result += static_cast<char>(0x80u | ((cp >> 6) & 0x3Fu));
+            result += static_cast<char>(0x80u | (cp & 0x3Fu));
+        }
+    }
+    return result;
 }
 
 std::wstring utf8_decode(const std::string &source)
 {
-    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(source);
+    std::wstring result;
+    size_t i = 0;
+    while (i < source.size()) {
+        auto c = static_cast<unsigned char>(source[i]);
+        uint32_t cp;
+        if (c < 0x80u) {
+            cp = c; i++;
+        } else if ((c & 0xE0u) == 0xC0u && i + 1 < source.size()) {
+            cp = (static_cast<uint32_t>(c & 0x1Fu) << 6)
+               |  static_cast<uint32_t>(static_cast<unsigned char>(source[i+1]) & 0x3Fu);
+            i += 2;
+        } else if ((c & 0xF0u) == 0xE0u && i + 2 < source.size()) {
+            cp = (static_cast<uint32_t>(c & 0x0Fu) << 12)
+               | (static_cast<uint32_t>(static_cast<unsigned char>(source[i+1]) & 0x3Fu) << 6)
+               |  static_cast<uint32_t>(static_cast<unsigned char>(source[i+2]) & 0x3Fu);
+            i += 3;
+        } else if ((c & 0xF8u) == 0xF0u && i + 3 < source.size()) {
+            cp = (static_cast<uint32_t>(c & 0x07u) << 18)
+               | (static_cast<uint32_t>(static_cast<unsigned char>(source[i+1]) & 0x3Fu) << 12)
+               | (static_cast<uint32_t>(static_cast<unsigned char>(source[i+2]) & 0x3Fu) << 6)
+               |  static_cast<uint32_t>(static_cast<unsigned char>(source[i+3]) & 0x3Fu);
+            i += 4;
+        } else {
+            i++; continue; // invalid byte, skip
+        }
+#ifdef _WIN32
+        // wchar_t is UTF-16 on Windows; emit surrogate pair if needed
+        if (cp >= 0x10000u) {
+            cp -= 0x10000u;
+            result += static_cast<wchar_t>(0xD800u + (cp >> 10));
+            result += static_cast<wchar_t>(0xDC00u + (cp & 0x3FFu));
+        } else {
+            result += static_cast<wchar_t>(cp);
+        }
+#else
+        result += static_cast<wchar_t>(cp);
+#endif
+    }
+    return result;
 }
 
 std::string copyArrayOrBufferIntoVector(const Napi::Value &val, std::vector<unsigned char> &message)


### PR DESCRIPTION
- Bump node-addon-api from ^3.2.1 to ^8.8.0 since
  node-addon-api v3.x has broken TypedThreadSafeFunction template constructors
  against Node v21+ headers
- Replace deprecated std::wstring_convert/std::codecvt_utf8 in util.cc
  with a hand-rolled UTF-8 converter (deprecated in C++17, removed in C++26);
  handles Windows UTF-16 surrogate pairs and macOS/Linux UCS-4 wchar_t.
  (created by Claude from RFC 3629 and Unicode Standard Section 3.8)
- Specify explicit std:C++17 since node-addon-api v8 uses std::string_view 
   and "if constexpr" which require C++17
- Bump minimum Node version from Node 14 to Node 16 in CI builds
- Bump node-hid version to 3.4.0